### PR TITLE
feat(schema): add hero section module schema

### DIFF
--- a/src/sanity/schemaTypes/fragments/modules.ts
+++ b/src/sanity/schemaTypes/fragments/modules.ts
@@ -8,6 +8,7 @@ export default defineField({
     { type: 'videoHero' },
     { type: 'galleryHero' },
     { type: 'featuredHero' },
+    { type: 'hero' },
     { type: 'accordion-list' },
     { type: 'feature-grid' },
     { type: 'callout' },
@@ -33,7 +34,7 @@ export default defineField({
       groups: [
         {
           name: 'Hero Sections',
-          of: [ 'featuredHero', 'videoHero', 'galleryHero'],
+          of: [ 'featuredHero', 'videoHero', 'galleryHero', 'hero'],
         },
         {
           name: 'Content Blocks',

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -41,6 +41,7 @@ import callout from './modules/callout';
 import featureGrid from './modules/feature-grid';
 import featuredHero from './modules/featured-hero';
 import galleryHero from './modules/gallery-hero';
+import hero from './modules/hero';
 import logoList from './modules/logo-list';
 
 import personList from './modules/person-list';
@@ -90,7 +91,7 @@ export const schemaTypes: SchemaTypeDefinition[] = [
   featuredHero,
   galleryHero,
   featureGrid,
-
+  hero,
   logoList,
 
   personList,

--- a/src/sanity/schemaTypes/modules/hero.ts
+++ b/src/sanity/schemaTypes/modules/hero.ts
@@ -1,0 +1,87 @@
+/**
+ * Hero Section Module Schema
+ * @version 1.0.0
+ * @lastUpdated 2024-05-10
+ * @changelog
+ * - 1.0.0: Initial version
+ */
+
+import { BsColumns } from "react-icons/bs";
+import { defineField, defineType } from "sanity";
+
+export default defineType({
+  name: "hero",
+  title: "Hero Section",
+  icon: BsColumns,
+  type: "object",
+  groups: [
+    { name: "content", title: "Content", default: true },
+    { name: "image", title: "Image" },
+    { name: "options", title: "Options" },
+  ],
+  preview: {
+    select: {
+      title: "title",
+      highlightedTitle: "highlightedTitle",
+      pretitle: "pretitle",
+      media: "image",
+    },
+    prepare: ({ title, highlightedTitle, pretitle, media }) => {
+      return {
+        title: title || "Hero Section",
+        subtitle: pretitle || (highlightedTitle ? `Highlighted: ${highlightedTitle}` : "Hero Section"),
+        media: media?.image || BsColumns,
+      };
+    },
+  },
+  fields: [
+    defineField({
+      name: "options",
+      type: "module-options",
+      group: "options",
+    }),
+    defineField({
+      name: "pretitle",
+      title: "Pre-title",
+      description: "Small badge text displayed above the title",
+      type: "string",
+      group: "content",
+    }),
+    defineField({
+      name: "highlightedTitle",
+      title: "Highlighted Title",
+      description: "This text will appear highlighted above the main title",
+      type: "string",
+      group: "content",
+    }),
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      group: "content",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "description",
+      title: "Description",
+      type: "text",
+      rows: 3,
+      group: "content",
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: "ctas",
+      title: "Call-to-actions",
+      description: "Add buttons for the hero section",
+      type: "array",
+      of: [{ type: "cta" }],
+      group: "content",
+    }),
+    defineField({
+      name: "image",
+      title: "Image",
+      type: "img",
+      group: "image",
+    }),
+  ],
+}); 

--- a/src/types/Sanity.d.ts
+++ b/src/types/Sanity.d.ts
@@ -330,6 +330,16 @@ declare global {
     interface ModuleOptions {
       isFullWidth?: boolean;
     }
+
+    // Add Hero module interface
+    interface Hero extends Module<'hero'> {
+      pretitle?: string;
+      highlightedTitle?: string;
+      title: string;
+      description: string;
+      ctas?: CTA[];
+      image?: Img;
+    }
   }
 }
 export {};

--- a/src/ui/modules/hero/Hero.tsx
+++ b/src/ui/modules/hero/Hero.tsx
@@ -1,0 +1,84 @@
+import type React from "react"
+import { ArrowRight } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import { Img } from "@/ui/Img"
+
+import CTAList from "@/ui/CTAList"
+import Pretitle from "@/ui/Pretitle"
+import { stegaClean } from "next-sanity"
+
+export default function Hero(props: Sanity.Hero & { className?: string; isTabbedModule?: boolean }) {
+  const { className, isTabbedModule = false } = props;
+
+  return (
+    <section
+      className={cn(
+        "relative overflow-hidden bg-gradient-to-b from-background via-background to-muted/30", 
+        !isTabbedModule && "py-24 md:py-32 lg:py-40",
+        className
+      )}
+    >
+      {/* Decorative elements */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-[30%] -right-[10%] w-[70%] h-[70%] rounded-full bg-gradient-to-br from-rose-500/20 to-purple-500/20 blur-3xl opacity-70 dark:from-rose-500/10 dark:to-purple-500/10"></div>
+        <div className="absolute -bottom-[20%] -left-[10%] w-[60%] h-[60%] rounded-full bg-gradient-to-tr from-blue-500/20 to-cyan-500/20 blur-3xl opacity-70 dark:from-blue-500/10 dark:to-cyan-500/10"></div>
+      </div>
+
+      <div className="container relative z-10 px-4">
+        <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 items-center">
+          <div className="flex flex-col max-w-3xl">
+            {props.pretitle && (
+              <Pretitle className="mb-6">{props.pretitle}</Pretitle>
+            )}
+            <h1 className="text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl">
+              {props.highlightedTitle ? (
+                <>
+                  <span className="inline-block mb-2 bg-gradient-to-r from-rose-500 to-rose-700 bg-clip-text text-transparent dark:text-rose-400 font-extrabold">
+                    {props.highlightedTitle}
+                  </span>{" "}
+                  <br />
+                </>
+              ) : null}
+              <span>{props.title}</span>
+            </h1>
+
+            <p className="mt-6 text-xl text-muted-foreground leading-relaxed">{props.description}</p>
+
+            {/* Call-to-actions section */}
+            {props.ctas && props.ctas.length > 0 && (
+              <div className="mt-10">
+                <CTAList 
+                  className="flex flex-col sm:flex-row gap-4" 
+                  ctas={stegaClean(props.ctas)} 
+                />
+              </div>
+            )}
+          </div>
+
+          {props.image && (
+            <div className="relative lg:ml-auto">
+              <div className="relative z-10 overflow-hidden rounded-2xl shadow-2xl">
+                <div className="aspect-[4/3] md:aspect-[16/9] bg-gradient-to-br from-gray-900 to-gray-800">
+                  <Img 
+                    image={props.image.image}
+                    className="w-full h-full object-cover" 
+                    alt={props.image.alt || props.image.image?.alt || "Hero image"}
+                  />
+                </div>
+              </div>
+
+              {/* Image decorative elements */}
+              <div className="absolute -bottom-6 -left-6 w-24 h-24 rounded-full bg-rose-600/30 blur-xl"></div>
+              <div className="absolute -top-6 -right-6 w-32 h-32 rounded-full bg-purple-600/20 blur-xl"></div>
+
+              {/* Decorative pattern */}
+              <div className="absolute -bottom-4 -right-4 w-32 h-32 bg-gradient-to-br from-rose-600/20 to-transparent rounded-tl-3xl"></div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+} 

--- a/src/ui/modules/hero/Hero.tsx
+++ b/src/ui/modules/hero/Hero.tsx
@@ -14,11 +14,7 @@ export default function Hero(props: Sanity.Hero & { className?: string; isTabbed
 
   return (
     <section
-      className={cn(
-        "relative overflow-hidden bg-gradient-to-b from-background via-background to-muted/30", 
-        !isTabbedModule && "py-24 md:py-32 lg:py-40",
-        className
-      )}
+      className={cn(!isTabbedModule && "py-24 sm:py-32", className)}
     >
       {/* Decorative elements */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
@@ -26,55 +22,55 @@ export default function Hero(props: Sanity.Hero & { className?: string; isTabbed
         <div className="absolute -bottom-[20%] -left-[10%] w-[60%] h-[60%] rounded-full bg-gradient-to-tr from-blue-500/20 to-cyan-500/20 blur-3xl opacity-70 dark:from-blue-500/10 dark:to-cyan-500/10"></div>
       </div>
 
-      <div className="container relative z-10 px-4">
-        <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 items-center">
-          <div className="flex flex-col max-w-3xl">
-            {props.pretitle && (
-              <Pretitle className="mb-6">{props.pretitle}</Pretitle>
-            )}
-            <h1 className="text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl">
-              {props.highlightedTitle ? (
-                <>
-                  <span className="inline-block mb-2 bg-gradient-to-r from-rose-500 to-rose-700 bg-clip-text text-transparent dark:text-rose-400 font-extrabold">
-                    {props.highlightedTitle}
-                  </span>{" "}
-                  <br />
-                </>
-              ) : null}
-              <span>{props.title}</span>
-            </h1>
+      <div className="mx-auto max-w-7xl px-6 lg:px-8">
+        <div className="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-2">
+          <div className="lg:pt-4 lg:pr-4">
+            <div className="lg:max-w-lg mb-10">
+              {props.pretitle && (
+                <Pretitle className="mb-6">{props.pretitle}</Pretitle>
+              )}
+              <h1 className="text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl">
+                {props.highlightedTitle ? (
+                  <>
+                    <span className="inline-block mb-2 bg-gradient-to-r from-rose-500 to-rose-700 bg-clip-text text-transparent dark:text-rose-400 font-extrabold">
+                      {props.highlightedTitle}
+                    </span>{" "}
+                    <br />
+                  </>
+                ) : null}
+                <span>{props.title}</span>
+              </h1>
 
-            <p className="mt-6 text-xl text-muted-foreground leading-relaxed">{props.description}</p>
+              <p className="mt-6 text-xl text-muted-foreground leading-relaxed">{props.description}</p>
 
-            {/* Call-to-actions section */}
-            {props.ctas && props.ctas.length > 0 && (
-              <div className="mt-10">
-                <CTAList 
-                  className="flex flex-col sm:flex-row gap-4" 
-                  ctas={stegaClean(props.ctas)} 
-                />
-              </div>
-            )}
+              {/* Call-to-actions section */}
+              {props.ctas && props.ctas.length > 0 && (
+                <div className="mt-8 flex gap-4">
+                  <CTAList 
+                    className="max-sm:min-w-full" 
+                    ctas={stegaClean(props.ctas)} 
+                  />
+                </div>
+              )}
+            </div>
           </div>
 
           {props.image && (
-            <div className="relative lg:ml-auto">
-              <div className="relative z-10 overflow-hidden rounded-2xl shadow-2xl">
+            <div className="flex items-center lg:items-start justify-center lg:justify-end lg:pt-4">
+              <div className="relative overflow-hidden rounded-xl shadow-xl ring-1 ring-border">
                 <div className="aspect-[4/3] md:aspect-[16/9] bg-gradient-to-br from-gray-900 to-gray-800">
                   <Img 
                     image={props.image.image}
-                    className="w-full h-full object-cover" 
+                    className="w-[48rem] max-w-none object-cover sm:w-[57rem]" 
                     alt={props.image.alt || props.image.image?.alt || "Hero image"}
                   />
                 </div>
+
+                {/* Image decorative elements */}
+                <div className="absolute -bottom-6 -left-6 w-24 h-24 rounded-full bg-rose-600/30 blur-xl"></div>
+                <div className="absolute -top-6 -right-6 w-32 h-32 rounded-full bg-purple-600/20 blur-xl"></div>
+                <div className="absolute -bottom-4 -right-4 w-32 h-32 bg-gradient-to-br from-rose-600/20 to-transparent rounded-tl-3xl"></div>
               </div>
-
-              {/* Image decorative elements */}
-              <div className="absolute -bottom-6 -left-6 w-24 h-24 rounded-full bg-rose-600/30 blur-xl"></div>
-              <div className="absolute -top-6 -right-6 w-32 h-32 rounded-full bg-purple-600/20 blur-xl"></div>
-
-              {/* Decorative pattern */}
-              <div className="absolute -bottom-4 -right-4 w-32 h-32 bg-gradient-to-br from-rose-600/20 to-transparent rounded-tl-3xl"></div>
             </div>
           )}
         </div>

--- a/src/ui/modules/index.tsx
+++ b/src/ui/modules/index.tsx
@@ -5,6 +5,7 @@ import Callout from './Callout';
 import FeatureGrid from './FeatureGrid';
 import FeaturedHero from './FeaturedHero';
 import { HeroImageGallery } from './HeroImageGallery';
+import Hero from './hero/Hero';
 import LogoList from './LogoList';
 import PersonList from './PersonList';
 import PricingList from './PricingList';
@@ -64,6 +65,8 @@ export default function Modules({
             return <FeaturedHero {...module} key={module._key} isTabbedModule={isTabbedModule} />;
           case 'galleryHero':
             return <HeroImageGallery {...module} key={module._key} />;
+          case 'hero':
+            return <Hero {...(module as Sanity.Hero)} key={module._key} isTabbedModule={isTabbedModule} />;
 
           case 'logo-list':
             return <LogoList {...module} key={module._key} isTabbedModule={isTabbedModule} />;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Hero" section module, allowing for customizable hero sections with titles, descriptions, images, and call-to-action buttons.
  - Added support for rendering the new Hero module within the user interface, featuring enhanced visuals and flexible content layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->