### PR TITLE
fix(page): resolve params as a promise in page and metadata functions

### DIFF
--- a/src/app/(frontend)/[locale]/[...slug]/page.tsx
+++ b/src/app/(frontend)/[locale]/[...slug]/page.tsx
@@ -13,7 +13,8 @@ import Modules from '@/ui/modules';
 import { PageProvider } from '@/contexts/PageContext';
 
 export default async function Page({ params }: Props) {
-  const page = await getPage(params);
+  const resolvedParams = await params;
+  const page = await getPage(resolvedParams);
   if (!page) notFound();
   return (
     <PageProvider page={page}>
@@ -23,7 +24,8 @@ export default async function Page({ params }: Props) {
 }
 
 export async function generateMetadata({ params }: Props) {
-  const page = await getPage(params);
+  const resolvedParams = await params;
+  const page = await getPage(resolvedParams);
   if (!page) notFound();
   return processMetadata(page);
 }
@@ -76,5 +78,5 @@ async function getPage(params: { slug?: string[] }) {
 }
 
 type Props = {
-  params: { slug?: string[] };
+  params: Promise<{ slug?: string[] }>;
 };


### PR DESCRIPTION
### **User description**
- Updated the `Page` and `generateMetadata` functions to handle `params` as a promise.
- Ensured that the `getPage` function receives the resolved parameters for accurate data retrieval.
- Adjusted the `Props` type definition to reflect the change in `params` type.


___

### **PR Type**
Bug fix


___

### **Description**
- Handle `params` as a promise in `Page` and `generateMetadata` functions

- Resolve params before passing to `getPage` for accurate data retrieval

- Update `Props` type to reflect `params` as `Promise` type


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Page/generateMetadata receives params"] -- "await params" --> B["resolvedParams"]
  B -- "pass to getPage" --> C["getPage processes resolved params"]
  D["Props type updated"] -- "params: Promise" --> E["Type alignment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Resolve params promise in page functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/(frontend)/[locale]/[...slug]/page.tsx

<ul><li>Added <code>await params</code> to resolve the promise before passing to <code>getPage</code> in <br>both <code>Page</code> and <code>generateMetadata</code> functions<br> <li> Updated <code>Props</code> type definition to declare <code>params</code> as <code>Promise<{ slug?: </code><br><code>string[] }></code> instead of <code>{ slug?: string[] }</code><br> <li> Ensures resolved parameters are used for accurate page data retrieval</ul>


</details>


  </td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/145/files#diff-ecb66864710b9f5d7cd489f9f78de3ee33b7a9fa2fab89c27a08e678161f3b82">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

