### PR TITLE
Build fix

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -7,13 +7,28 @@ IMAGE_NAME=${1:-nextmedal}
 
 echo "🚀 Starting Docker build for $IMAGE_NAME..."
 
-# Build the argument list from .env
-# 1. Read .env file
-# 2. Remove comments and empty lines
-# 3. Format as --build-arg KEY=VALUE
-BUILD_ARGS=$(grep -v '^#' .env | grep -v '^$' | xargs -I {} echo "--build-arg {}" | xargs)
+# Build arguments for Next.js (only those needed at build time)
+# We specifically pick only the variables the Dockerfile expects to avoid leaking other secrets
+REQUIRED_ARGS=(
+  "NEXT_PUBLIC_SANITY_PROJECT_ID"
+  "NEXT_PUBLIC_SANITY_DATASET"
+  "NEXT_PUBLIC_BASE_URL"
+  "SANITY_API_READ_TOKEN"
+  "NEXT_PUBLIC_UMAMI_SCRIPT_URL"
+  "NEXT_PUBLIC_UMAMI_WEBSITE_ID"
+  "NEXT_PUBLIC_APP_ENV"
+)
 
-echo "🛠️ Build arguments detected: $BUILD_ARGS"
+BUILD_ARGS=""
+for ARG in "${REQUIRED_ARGS[@]}"; do
+  # Extract value from .env if it exists
+  VALUE=$(grep "^$ARG=" .env | cut -d'=' -f2- | sed 's/^"//;s/"$//;s/^\x27//;s/\x27$//')
+  if [ ! -z "$VALUE" ]; then
+    BUILD_ARGS="$BUILD_ARGS --build-arg $ARG=$VALUE"
+  fi
+done
+
+echo "🛠️ Build arguments prepared (filtered from .env)"
 
 # Execute build
 docker build $BUILD_ARGS -t "$IMAGE_NAME" .

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -31,15 +31,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Revalidate the specific document type
-    // Next.js 16 (or this canary version) requires a second argument for revalidateTag,
-    // but we use a try/catch to handle both signatures for cross-version compatibility.
-    try {
-      // @ts-ignore - Handle possible two-argument signature in Next.js 16
-      revalidateTag(body._type, 'default');
-    } catch (e) {
-      // Fallback to standard single-argument signature
-      revalidateTag(body._type);
-    }
+    revalidateTag(body._type, 'max');
     logger.info({ msg: 'Revalidated tag', type: body._type });
 
     // If it's a page or post with a slug, we might want to be more specific,


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactor Docker build script to filter and whitelist required environment variables
  - Prevents accidental exposure of sensitive secrets during build
  - Only passes explicitly defined variables to Docker build

- Simplify revalidateTag API call by removing version compatibility workaround
  - Update to use 'max' revalidation strategy instead of try/catch fallback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Build Script"] -->|"Filter ENV vars"| B["Whitelist Required Args"]
  B -->|"Extract from .env"| C["Build Arguments"]
  C -->|"Pass to Docker"| D["Docker Build"]
  E["Revalidate Route"] -->|"Simplify API"| F["Remove Version Compat"]
  F -->|"Use max strategy"| G["revalidateTag"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-build.sh</strong><dd><code>Whitelist and filter environment variables for Docker build</code></dd></summary>
<hr>

scripts/docker-build.sh

<ul><li>Replace generic .env parsing with explicit whitelist of required build <br>arguments<br> <li> Define REQUIRED_ARGS array containing only necessary Next.js and <br>Sanity configuration variables<br> <li> Implement selective extraction from .env file with proper quote <br>handling<br> <li> Update logging to reflect filtered approach instead of detecting all <br>arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/198/files#diff-d30c84327513edc188b843954c234163168a1b35c2e4230ebfbc41bd0ad0af94">+22/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Simplify revalidateTag API call with max strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/revalidate/route.ts

<ul><li>Remove try/catch wrapper handling Next.js version compatibility for <br>revalidateTag<br> <li> Simplify revalidateTag call to use single invocation with 'max' <br>revalidation strategy<br> <li> Eliminate @ts-ignore comment and cross-version fallback logic</ul>


</details>


  </td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/198/files#diff-4e5168fb03bba42b13ededc5e605daba7c34cd795bd96e6847372d1f6a75c0ab">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

