### PR TITLE
feat(styles): add dark mode selection styling for improved user exper…

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -176,6 +176,7 @@
 */
 
 :root {
+  --banner-height: 0px;
   --header-height: 4rem;
   --header-z-index: 50;
 
@@ -404,6 +405,21 @@ samp,
   ::selection {
     background-color: var(--color-brand-lavender);
     color: var(--color-brand-purple);
+  }
+
+  /* Dark mode specific selection - Muted Steel Violet */
+  .dark ::selection {
+    /* 
+       "Steel Violet" - A very desaturated, mid-tone slate.
+       Tuned down significantly:
+       - Lightness: 0.40 (visible but not bright)
+       - Chroma: 0.06 (very low saturation, almost gray)
+       - Hue: 285 (matches brand hue, but barely)
+       This feels like a native OS selection but subtly tinted to the brand.
+    */
+    background-color: oklch(0.40 0.06 285);
+    /* Keep text white for readability */
+    color: oklch(0.985 0 0);
   }
 
   [hidden] {

--- a/src/ui/header/Header.client.tsx
+++ b/src/ui/header/Header.client.tsx
@@ -75,21 +75,37 @@ export default function HeaderClient({
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Set --header-height
+  // Set --header-height (includes banner height for proper content offset)
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
     function setHeight() {
       if (!ref.current) return;
+      const bannerHeight =
+        Number.parseInt(
+          getComputedStyle(document.documentElement).getPropertyValue('--banner-height') || '0',
+          10
+        ) || 0;
+      const headerHeight = ref.current.offsetHeight ?? 0;
       document.documentElement.style.setProperty(
         '--header-height',
-        `${ref.current.offsetHeight ?? 0}px`
+        `${bannerHeight + headerHeight}px`
       );
     }
     setHeight();
     window.addEventListener('resize', setHeight, { passive: true });
 
-    return () => window.removeEventListener('resize', setHeight);
+    // Also listen for banner height changes via MutationObserver on style attribute
+    const observer = new MutationObserver(setHeight);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['style'],
+    });
+
+    return () => {
+      window.removeEventListener('resize', setHeight);
+      observer.disconnect();
+    };
   }, []);
 
   // Close mobile menu on route change

--- a/src/ui/header/index.tsx
+++ b/src/ui/header/index.tsx
@@ -54,7 +54,7 @@ export default async function Header() {
 
   return (
     <HeaderClient
-      className="@container fixed top-0 w-full z-50"
+      className="@container fixed top-[var(--banner-height,0px)] w-full z-50"
       role="banner"
       aria-label="Site header"
       ctas={ctas ?? []}

--- a/src/ui/layout/Banner.client.tsx
+++ b/src/ui/layout/Banner.client.tsx
@@ -2,54 +2,107 @@
 import { X } from 'lucide-react';
 import Link from 'next/link';
 import { PortableText } from 'next-sanity';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
 import resolveUrl from '@/lib/resolveUrl';
 import { Scheduler } from '@/ui/utility';
+
+function BannerContent({
+  content,
+  cta,
+  onClose,
+}: {
+  content: Sanity.Banner['content'];
+  cta: Sanity.Banner['cta'];
+  onClose: () => void;
+}) {
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  // Update CSS variable for banner height
+  useEffect(() => {
+    const updateBannerHeight = () => {
+      if (bannerRef.current) {
+        document.documentElement.style.setProperty(
+          '--banner-height',
+          `${bannerRef.current.offsetHeight}px`
+        );
+      }
+    };
+
+    // Use RAF to ensure DOM is ready
+    requestAnimationFrame(updateBannerHeight);
+    window.addEventListener('resize', updateBannerHeight, { passive: true });
+
+    return () => {
+      window.removeEventListener('resize', updateBannerHeight);
+      document.documentElement.style.setProperty('--banner-height', '0px');
+    };
+  }, []);
+
+  return (
+    <div
+      ref={bannerRef}
+      className="fixed top-0 left-0 right-0 z-[60] flex items-center justify-center gap-x-6 bg-brand-700 text-white px-6 py-2 sm:px-3.5"
+    >
+      <div className="relative flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
+        <div className="text-sm font-medium [&_p]:m-0 [&_p]:leading-normal">
+          <PortableText
+            value={content}
+            components={{
+              block: {
+                normal: ({ children }) => <p className="inline">{children}</p>,
+              },
+            }}
+          />
+        </div>
+
+        {cta?.label && (
+          <Link
+            href={
+              cta?.type === 'internal'
+                ? resolveUrl(cta.internal, { base: false })
+                : cta?.external
+                  ? cta.external
+                  : '#'
+            }
+            target={cta?.external ? '_blank' : undefined}
+            className="inline-flex items-center justify-center rounded-md border border-transparent bg-white px-2.5 h-8 text-sm font-medium text-brand-700 hover:bg-white/90 transition-all focus-visible:ring-[3px] focus-visible:ring-white/50 outline-none"
+          >
+            {cta.label}
+          </Link>
+        )}
+      </div>
+      <div className="absolute right-0 top-0 bottom-0 flex items-center pr-4">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={onClose}
+          className="text-white/80 hover:text-white hover:bg-white/10"
+        >
+          <span className="sr-only">Dismiss</span>
+          <X aria-hidden="true" className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export default function BannerClient({ banner }: { banner: Sanity.Banner & Sanity.Module }) {
   const { start, end, content, cta } = banner;
   const [isClosed, setIsClosed] = useState(false);
-  return (
-    !isClosed && (
-      <Scheduler start={start} end={end}>
-        <div className="relative isolate flex items-center justify-center gap-x-6 overflow-hidden bg-gradient-brand text-white px-6 py-2.5 sm:px-3.5">
-          <div className="relative flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
-            <div className="text-sm font-medium text-white/90 [&_p]:m-0 [&_p]:leading-normal">
-              <PortableText
-                value={content}
-                components={{
-                  block: {
-                    normal: ({ children }) => <p className="inline">{children}</p>,
-                  },
-                }}
-              />
-            </div>
 
-            <Link
-              href={
-                cta?.type === 'internal'
-                  ? resolveUrl(cta.internal, { base: false })
-                  : cta?.external
-                    ? cta.external
-                    : '#'
-              }
-              target={cta?.external && '_blank'}
-              className="flex-none inline-flex items-center justify-center rounded-full bg-white px-4 py-1 text-sm font-bold text-brand-navy shadow-sm hover:bg-white/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white transition-colors leading-none h-7"
-            >
-              {cta?.label}
-            </Link>
-          </div>
-          <div className="absolute right-0 top-0 bottom-0 flex items-center pr-4">
-            <button
-              type="button"
-              className="-m-3 p-1 focus-visible:outline-offset-[-4px] hover:bg-white/10 rounded-full transition-colors"
-              onClick={() => setIsClosed(true)}
-            >
-              <span className="sr-only">Dismiss</span>
-              <X aria-hidden="true" className="size-4 text-white/80 hover:text-white" />
-            </button>
-          </div>
-        </div>
-      </Scheduler>
-    )
+  // Reset banner height when closed
+  useEffect(() => {
+    if (isClosed) {
+      document.documentElement.style.setProperty('--banner-height', '0px');
+    }
+  }, [isClosed]);
+
+  if (isClosed) return null;
+
+  return (
+    <Scheduler start={start} end={end}>
+      <BannerContent content={content} cta={cta} onClose={() => setIsClosed(true)} />
+    </Scheduler>
   );
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add dark mode selection styling with muted Steel Violet background

- Implement banner height CSS variable for dynamic layout offset

- Update header positioning to account for banner height

- Refactor Banner component with improved styling and close behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dark Mode Selection Styles"] --> B["Updated globals.css"]
  C["Banner Height CSS Variable"] --> D["Header Positioning"]
  E["Banner Component Refactor"] --> F["Dynamic Height Tracking"]
  D --> G["Improved Layout Management"]
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>globals.css</strong><dd><code>Dark mode selection styling and banner height variable</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/styles/globals.css

<ul><li>Added <code>--banner-height</code> CSS variable initialized to 0px<br> <li> Introduced dark mode specific <code>::selection</code> styling with muted Steel <br>Violet background (oklch 0.40 0.06 285)<br> <li> Set selection text color to white for improved readability in dark <br>mode<br> <li> Maintained existing light mode selection styling with lavender <br>background</ul>


</details>


  </td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/282/files#diff-dd438e7ca4da8a47a35709920a07b6fef918609c1daa40f6e9b794ddfd3e4996">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Header.client.tsx</strong><dd><code>Header height calculation with banner offset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ui/header/Header.client.tsx

<ul><li>Updated <code>--header-height</code> calculation to include <code>--banner-height</code> offset<br> <li> Added logic to read banner height from CSS variable and add to header <br>height<br> <li> Implemented MutationObserver to listen for banner height style changes<br> <li> Enhanced cleanup function to properly disconnect observer on unmount</ul>


</details>


  </td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/282/files#diff-526f8ab870332afc820d376e7a817098b4916201679a90938f85b5513ca35b33">+19/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Dynamic header positioning with banner offset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ui/header/index.tsx

<ul><li>Changed header positioning from <code>top-0</code> to <br><code>top-[var(--banner-height,0px)]</code><br> <li> Allows header to dynamically position below banner when present<br> <li> Maintains fallback to 0px when banner is not visible</ul>


</details>


  </td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/282/files#diff-10ab559ca93324b3943c3b57ad8e08739f837d61c6f68df5ac21230e7649b37f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Banner.client.tsx</strong><dd><code>Banner component refactor with dynamic height tracking</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ui/layout/Banner.client.tsx

<ul><li>Extracted banner content into separate <code>BannerContent</code> component with <br>ref tracking<br> <li> Added <code>useEffect</code> hook to dynamically update <code>--banner-height</code> CSS <br>variable on mount and resize<br> <li> Implemented <code>requestAnimationFrame</code> for proper DOM timing<br> <li> Added cleanup effect to reset banner height to 0px when banner is <br>closed<br> <li> Updated styling from gradient background to solid <code>bg-brand-700</code><br> <li> Refactored close button to use Button component with improved <br>accessibility<br> <li> Improved CTA button styling with white background and hover states</ul>


</details>


  </td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/282/files#diff-15d5b6f27a1971138e88932e6d92bac9ea16431c49bb83ded0ad372b5171eba8">+96/-43</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

