### PR TITLE
fix: consolidate COLLECTION_TYPES and improve type safety

### DIFF
--- a/src/app/api/og/article-fallback/route.tsx
+++ b/src/app/api/og/article-fallback/route.tsx
@@ -29,6 +29,16 @@ function getLocalizedText(locale: string) {
   return TRANSLATIONS[normalizedLocale] || TRANSLATIONS.en;
 }
 
+/**
+ * Extract resolved site title from GROQ query result.
+ * GROQ coalesces internationalized arrays to strings at query time,
+ * but TypeScript types still expect the array structure.
+ */
+function getSiteName(site: Sanity.Site | null, fallback = 'NextMedal'): string {
+  if (!site?.title) return fallback;
+  return (site.title as unknown as string) || fallback;
+}
+
 function isRTL(locale: string): boolean {
   return locale.toLowerCase().startsWith('ar');
 }
@@ -92,9 +102,9 @@ export async function GET(request: NextRequest) {
     let siteName = 'NextMedal';
     try {
       const site = await getSiteOptional(locale);
-      if (site?.title) siteName = site.title as unknown as string;
+      siteName = getSiteName(site, 'NextMedal');
     } catch (_e) {
-      // Fallback
+      // Fallback to default
     }
 
     const t = getLocalizedText(locale);

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -18,6 +18,16 @@ const BRAND_COLORS = {
 const FALLBACK_SITE_TITLE = 'NextMedal';
 const MAX_TITLE_LENGTH = 140; // Tighter limit for large typography
 
+/**
+ * Extract resolved site title from GROQ query result.
+ * GROQ coalesces internationalized arrays to strings at query time,
+ * but TypeScript types still expect the array structure.
+ */
+function getSiteName(site: Sanity.Site | null): string {
+  if (!site?.title) return FALLBACK_SITE_TITLE;
+  return (site.title as unknown as string) || FALLBACK_SITE_TITLE;
+}
+
 async function loadFonts(): Promise<
   {
     name: string;
@@ -42,7 +52,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const site = await getSiteOptional().catch(() => null);
 
-    const siteTitle = (site?.title as unknown as string) || FALLBACK_SITE_TITLE;
+    const siteTitle = getSiteName(site);
     const domain = new URL(BASE_URL).hostname;
 
     // Remove site branding from the end of the title if present

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -3,13 +3,23 @@ import { DEFAULT_LOCALE } from '@/i18n/config';
 import { getSiteOptional } from '@/sanity/lib/fetch';
 import { getBlockText } from '@/sanity/lib/utils';
 
+/**
+ * Extract resolved site title from GROQ query result.
+ * GROQ coalesces internationalized arrays to strings at query time,
+ * but TypeScript types still expect the array structure.
+ */
+function getSiteName(site: Sanity.Site | null): string | undefined {
+  if (!site?.title) return undefined;
+  return site.title as unknown as string;
+}
+
 export default async function manifest(): Promise<MetadataRoute.Manifest> {
   // Colors from globals.css
   const THEME_COLOR = '#5B2D8C'; // --color-brand-600
   const BACKGROUND_COLOR = '#ffffff';
 
   const site = await getSiteOptional(DEFAULT_LOCALE);
-  const siteTitle = site?.title as unknown as string;
+  const siteTitle = getSiteName(site);
   const description = site?.tagline ? getBlockText(site.tagline as unknown, ' ') : undefined;
 
   return {

--- a/src/components/blocks/layout/language-switcher/LocaleSwitcher.client.tsx
+++ b/src/components/blocks/layout/language-switcher/LocaleSwitcher.client.tsx
@@ -3,7 +3,7 @@
 import { usePage } from '@/contexts';
 import { routing } from '@/i18n/routing';
 import { getCollectionSlugWithFallback } from '@/lib/collections/registry';
-import type { CollectionType } from '@/lib/collections/types';
+import { COLLECTION_TYPES, type CollectionType } from '@/lib/collections/types';
 import LocaleSwitcherSelect from './LocaleSwitcherSelect';
 
 export type Translation = {
@@ -33,14 +33,6 @@ export interface LocaleSwitcherClientProps {
   locale: string;
   labels: LocaleLabels;
 }
-
-const COLLECTION_TYPES: CollectionType[] = [
-  'collection.article',
-  'collection.documentation',
-  'collection.changelog',
-  'collection.newsletter',
-  'collection.events',
-];
 
 /**
  * Helper to build locale-prefixed URL (default locale has no prefix)

--- a/src/lib/collections/types.ts
+++ b/src/lib/collections/types.ts
@@ -14,6 +14,19 @@ export type CollectionType =
   | 'collection.events';
 
 /**
+ * All collection types as a runtime array
+ * This is the SINGLE SOURCE OF TRUTH for collection types.
+ * Import this instead of defining your own array.
+ */
+export const COLLECTION_TYPES: CollectionType[] = [
+  'collection.article',
+  'collection.documentation',
+  'collection.changelog',
+  'collection.newsletter',
+  'collection.events',
+] as const satisfies readonly CollectionType[];
+
+/**
  * Collection metadata interface
  */
 export interface CollectionMetadata {

--- a/src/lib/sanity/process-metadata.ts
+++ b/src/lib/sanity/process-metadata.ts
@@ -5,6 +5,19 @@ import { BASE_URL, dev, isPreview, isStaging, vercelPreview } from '@/lib/core/e
 import { getSiteOptional } from '@/sanity/lib/fetch';
 import resolveUrl from './resolve-url-server';
 
+/**
+ * Extract site title from GROQ-resolved site settings.
+ * GROQ queries resolve internationalized arrays to simple strings,
+ * but TypeScript types still expect the array structure.
+ * This helper safely extracts the resolved string value.
+ */
+function getSiteName(site: Sanity.Site | null): string | undefined {
+  if (!site?.title) return undefined;
+  // GROQ coalesces the i18n array to a string at query time
+  // Type assertion needed because TS sees InternationalizedArrayString but runtime is string
+  return site.title as unknown as string;
+}
+
 // Generate hreflang alternate URLs for all supported locales
 async function generateAlternateLanguages(
   page: Sanity.PageBase,
@@ -199,7 +212,7 @@ export default async function processMetadata(
       title: cleanTitle,
       description: cleanDescription,
       images: ogImage,
-      siteName: site?.title as unknown as string,
+      siteName: getSiteName(site),
       locale: ogLocale,
       ...(publishedTime && { publishedTime }),
     },

--- a/src/lib/sanity/resolve-url-server.ts
+++ b/src/lib/sanity/resolve-url-server.ts
@@ -2,17 +2,8 @@ import 'server-only';
 import { stegaClean } from 'next-sanity';
 import { routing } from '@/i18n/routing';
 import { getCollectionSlugWithFallback } from '@/lib/collections/registry';
-import type { CollectionType } from '@/lib/collections/types';
+import { COLLECTION_TYPES, type CollectionType } from '@/lib/collections/types';
 import { BASE_URL } from '@/lib/core/env';
-
-// Collection types that need collection slugs
-const COLLECTION_TYPES: CollectionType[] = [
-  'collection.article',
-  'collection.documentation',
-  'collection.changelog',
-  'collection.newsletter',
-  'collection.events',
-];
 
 // Build query string from params object
 function buildQueryString(

--- a/src/lib/sanity/resolve-url.ts
+++ b/src/lib/sanity/resolve-url.ts
@@ -1,17 +1,8 @@
 import { stegaClean } from 'next-sanity';
 import { routing } from '@/i18n/routing';
 import { getCollectionSlugWithFallback } from '@/lib/collections/registry';
-import type { CollectionType } from '@/lib/collections/types';
+import { COLLECTION_TYPES, type CollectionType } from '@/lib/collections/types';
 import { BASE_URL } from '@/lib/core/env';
-
-// Collection types that need collection slugs
-const COLLECTION_TYPES: CollectionType[] = [
-  'collection.article',
-  'collection.documentation',
-  'collection.changelog',
-  'collection.newsletter',
-  'collection.events',
-];
 
 // Helper function to detect if a URL is relative (starts with / or doesn't have a protocol)
 export function isRelativeUrl(url: string): boolean {

--- a/src/lib/sanity/translation-detector.ts
+++ b/src/lib/sanity/translation-detector.ts
@@ -17,15 +17,6 @@ export interface TranslationDetectionResult {
   strategy: 'exact-match' | 'not-found';
 }
 
-// Collection types that need collection slugs
-const _COLLECTION_TYPES: CollectionType[] = [
-  'collection.article',
-  'collection.documentation',
-  'collection.changelog',
-  'collection.newsletter',
-  'collection.events',
-];
-
 /**
  * Parse pathname to extract locale and slug
  * Patterns: /, /en, /nb, /en/slug, /nb/slug, /slug, /article/slug, /nb/article/slug

--- a/src/sanity/schemaTypes/modules/content/pricing-comparison.ts
+++ b/src/sanity/schemaTypes/modules/content/pricing-comparison.ts
@@ -147,14 +147,17 @@ export default defineType({
                       ],
                       validation: (Rule) =>
                         Rule.custom((featureTiers, context) => {
-                          // Look for the root document
-                          //@ts-expect-error
-                          const doc = context.document.modules.find(
-                            //@ts-expect-error
-                            (module) => module._key === context.path[1]._key
-                          );
+                          // Look for the root document's pricing-comparison module
+                          // @ts-expect-error - Sanity's validation context.document is typed as unknown but contains the full document with modules array
+                          const modules = context.document?.modules as
+                            | Array<{ _key: string; tiers?: unknown[] }>
+                            | undefined;
+                          // @ts-expect-error - Sanity's validation context.path contains path segments with _key but is typed as PathSegment[]
+                          const moduleKey = context.path[1]?._key as string | undefined;
+
+                          const doc = modules?.find((module) => module._key === moduleKey);
                           // Ensure document tiers is an array before accessing length
-                          const docTiers = Array.isArray(doc.tiers) ? doc.tiers : [];
+                          const docTiers = Array.isArray(doc?.tiers) ? doc.tiers : [];
                           const tierCount = docTiers.length;
 
                           if (!featureTiers)
@@ -203,16 +206,17 @@ export default defineType({
                               ],
                               validation: (Rule) =>
                                 Rule.custom((featureTiers, context) => {
-                                  // Look for the root document
-                                  //@ts-expect-error
-                                  const doc = context.document.modules.find(
-                                    //@ts-expect-error
-                                    (module) =>
-                                      //@ts-expect-error
-                                      module._key === context.path[1]._key
-                                  );
+                                  // Look for the root document's pricing-comparison module
+                                  // @ts-expect-error - Sanity's validation context.document is typed as unknown but contains the full document with modules array
+                                  const modules = context.document?.modules as
+                                    | Array<{ _key: string; tiers?: unknown[] }>
+                                    | undefined;
+                                  // @ts-expect-error - Sanity's validation context.path contains path segments with _key but is typed as PathSegment[]
+                                  const moduleKey = context.path[1]?._key as string | undefined;
+
+                                  const doc = modules?.find((module) => module._key === moduleKey);
                                   // Ensure document tiers is an array before accessing length
-                                  const docTiers = Array.isArray(doc.tiers) ? doc.tiers : [];
+                                  const docTiers = Array.isArray(doc?.tiers) ? doc.tiers : [];
                                   const tierCount = docTiers.length;
 
                                   if (!featureTiers)

--- a/src/sanity/ui/PageIdentityInput.tsx
+++ b/src/sanity/ui/PageIdentityInput.tsx
@@ -4,17 +4,14 @@ import { ClipboardIcon, EyeOpenIcon, LaunchIcon } from '@sanity/icons';
 import { Box, Button, Card, Flex, Stack, Text, TextInput, useToast } from '@sanity/ui';
 import { useCallback, useMemo, useState } from 'react';
 import { type ObjectInputProps, set, useFormValue } from 'sanity';
+import { COLLECTION_TYPES, type CollectionType } from '@/lib/collections/types';
 import { BASE_URL } from '@/lib/core/env.client';
 
-// Collection type identifiers
-type CollectionType =
-  | 'collection.article'
-  | 'collection.documentation'
-  | 'collection.changelog'
-  | 'collection.newsletter'
-  | 'collection.events';
-
-// Collection slugs (source of truth)
+/**
+ * Default collection slugs for URL preview in Sanity Studio.
+ * Note: These are fallback values. The actual slugs may vary per locale
+ * and are defined in the generated collections.generated.ts file.
+ */
 const DEFAULT_COLLECTION_SLUGS: Record<CollectionType, string> = {
   'collection.article': 'articles',
   'collection.documentation': 'docs',
@@ -22,14 +19,6 @@ const DEFAULT_COLLECTION_SLUGS: Record<CollectionType, string> = {
   'collection.newsletter': 'newsletter',
   'collection.events': 'events',
 };
-
-const COLLECTION_TYPES: CollectionType[] = [
-  'collection.article',
-  'collection.documentation',
-  'collection.changelog',
-  'collection.newsletter',
-  'collection.events',
-];
 
 /**
  * Custom input component for Page/Post Identity (title + slug)


### PR DESCRIPTION
### **User description**
- Create single source of truth for COLLECTION_TYPES in lib/collections/types.ts
- Update 5 files to import from central location instead of duplicating
- Add proper explanations to @ts-expect-error comments in pricing-comparison.ts
- Add getSiteName helper functions to safely extract GROQ-resolved site titles
- Improve type handling for Sanity's validation context in schema files


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Consolidate COLLECTION_TYPES into single source of truth in lib/collections/types.ts

- Update 6 files to import COLLECTION_TYPES instead of duplicating definitions

- Add getSiteName helper functions for safe GROQ-resolved site title extraction

- Improve type safety in pricing-comparison.ts validation with detailed @ts-expect-error explanations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["lib/collections/types.ts<br/>COLLECTION_TYPES definition"] -->|"import COLLECTION_TYPES"| B["resolve-url-server.ts"]
  A -->|"import COLLECTION_TYPES"| C["resolve-url.ts"]
  A -->|"import COLLECTION_TYPES"| D["LocaleSwitcher.client.tsx"]
  A -->|"import CollectionType"| E["PageIdentityInput.tsx"]
  F["getSiteName helpers"] -->|"extract site title"| G["manifest.ts"]
  F -->|"extract site title"| H["process-metadata.ts"]
  F -->|"extract site title"| I["article-fallback/route.tsx"]
  F -->|"extract site title"| J["og/route.tsx"]
  K["pricing-comparison.ts"] -->|"improved type handling"| L["validation context"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>types.ts</strong><dd><code>Create COLLECTION_TYPES as single source of truth</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-b170156eb1c1307c62cfc6c68372a0e2e3150bb837ca4ec0f7a8819d9a918dd0">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resolve-url-server.ts</strong><dd><code>Import COLLECTION_TYPES instead of duplicating</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-8718b8b1d37ed39731e3225de3bc89a3f3da3ca62cc5d9e5ae2da7a930368fc4">+1/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resolve-url.ts</strong><dd><code>Import COLLECTION_TYPES instead of duplicating</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-a170d890d8e8abe046da6b0c9654a828919c6dbd845651d89a925e41a33d610f">+1/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>translation-detector.ts</strong><dd><code>Remove unused COLLECTION_TYPES definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-f97b66297ebb107cb8fcf3f4648673097e35d63b7674fd8696db112c597f0dba">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LocaleSwitcher.client.tsx</strong><dd><code>Import COLLECTION_TYPES instead of duplicating</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-6291d814538c90236991453f967e759ee261d6651359ce425fa403eee80ec419">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PageIdentityInput.tsx</strong><dd><code>Import COLLECTION_TYPES and type from central location</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-aa66203bc476c89be8ba5ec6cd35f1ff5439e8425fe767ae905450039959a19d">+6/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manifest.ts</strong><dd><code>Add getSiteName helper for safe title extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-54c4d884a1d8b1b82c26ace697f5d9e3ae64ba6d7b8ece83c2f67c69b5441d3b">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>process-metadata.ts</strong><dd><code>Add getSiteName helper for safe title extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-9cfb9034baec3ad19c98c60ac6fa0357a466aeda9c7d89e74315d595d7eb1a46">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.tsx</strong><dd><code>Add getSiteName helper for safe title extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-aedf87e10b5c62b77ca41209bb9aa49eda7137d060011dc11fa22eb682ae221c">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>route.tsx</strong><dd><code>Add getSiteName helper for safe title extraction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-3a3e69669e4740a29efc4ec38bedd1f8f6a480a4493718cb633dde469cd0deb6">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pricing-comparison.ts</strong><dd><code>Improve type safety with detailed @ts-expect-error explanations</code></dd></td>
  <td><a href="https://github.com/Medal-Social/NextMedal/pull/318/files#diff-21b346bd188bd0359fc8cfe85e50f35242226457f2d1f4df4881fdaeabd1c0e1">+20/-16</a>&nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

