### PR TITLE
fix: resolve CTA internal link selector crash

### DIFF
--- a/src/sanity/components/CtaLinkInput.tsx
+++ b/src/sanity/components/CtaLinkInput.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@sanity/ui';
-import { type FieldMember, MemberField, type ObjectInputProps } from 'sanity';
+import { type FieldMember, type FieldSetMember, MemberField, type ObjectInputProps } from 'sanity';
 
 /**
  * This component is used specifically for the 'link' field inside the CTA.
@@ -10,13 +10,28 @@ import { type FieldMember, MemberField, type ObjectInputProps } from 'sanity';
  * It purposely ignores all other fields (label, type, external, params)
  * because they are already rendered by the parent CtaInput.
  */
+const findMember = (members: ObjectInputProps['members'], memberName: string) => {
+  if (!members || !Array.isArray(members)) return undefined;
+
+  const direct = members.find((m) => m.kind === 'field' && m.name === memberName) as
+    | FieldMember
+    | undefined;
+  if (direct) return direct;
+
+  const fieldsets = members.filter((m) => m.kind === 'fieldSet') as FieldSetMember[];
+  for (const fs of fieldsets) {
+    const nested = fs.fieldSet.members.find((m) => m.kind === 'field' && m.name === memberName) as
+      | FieldMember
+      | undefined;
+    if (nested) return nested;
+  }
+  return undefined;
+};
+
 export function CtaLinkInput(props: ObjectInputProps) {
   const { members, renderInput, renderItem, renderPreview, renderField } = props;
 
-  // We only want to render the 'internal' field (the reference picker)
-  const internalMember = members.find((m) => m.kind === 'field' && m.name === 'internal') as
-    | FieldMember
-    | undefined;
+  const internalMember = findMember(members, 'internal');
 
   if (!internalMember) {
     return null;


### PR DESCRIPTION
## Summary
- Fixed unhandled runtime error when selecting Internal destination type in CTA
- The internal reference picker was not rendering because `CtaLinkInput` only searched direct members, not nested fields within fieldsets
- Added `findMember` helper to search both direct fields and fieldsets, matching the pattern in `MenuItemInput`

## Fixes
- Fixes #321

## Testing
- Verified component renders without errors
- No visual changes to working functionality