### PR TITLE
chore: normalize copyright year and add NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Medal Social
+   Copyright 2023-2026 Medal Social
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Medal Social
+https://medal.tv
+
+Copyright 2023-2026 Medal Social
+
+This product includes software developed at Medal Social.


### PR DESCRIPTION
Relicense this project from its previous license (MIT / ISC / none) to Apache-2.0 for consistency across Medal Social's open-source surface.

Changes:
- Replace LICENSE file(s) with Apache-2.0 text
- Normalize copyright line to `Copyright 2023-2026 Medal Social`
- Add NOTICE file
- Update `package.json` `license` fields
- Rewrite `SPDX-License-Identifier` headers in source files where present
- Update README license section / badge