### PR TITLE
chore(ci): silence broken Dependabot security-update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# NextMedal uses Renovate (.github/renovate.json) for all dependency updates.
+# This file intentionally declares zero ecosystems so GitHub does not start
+# routine Dependabot version-update PRs.
+#
+# Dependabot security updates are controlled separately at the repo level
+# (Settings → Code security → Dependabot security updates). They are
+# DISABLED for this repo because they currently crash on pnpm 10 + lockfile
+# v9 with `unknown_error` deep inside the npm-updater Ruby image. We
+# address vulnerabilities through Renovate + manual review instead.
+#
+# Re-enabling: requires GitHub to ship a fix for pnpm 10 lockfile handling
+# in dependabot-updater-npm AND a deliberate decision to run two update
+# bots in parallel. Don't re-enable casually — coordinate with @alioftech.
+version: 2
+updates: []


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` with `updates: []` documenting that we use Renovate for all dep updates.
- The repo-level toggle to disable Dependabot security updates (`Settings → Code security → Dependabot security updates`) is a separate manual action by the maintainer (Task 1A.3 of the plan) — **not part of this PR**. This PR only commits the documentation file; the toggle still needs to be flipped after merge for the workflow to actually stop running.

## Why

GitHub's auto-Dependabot security-update workflow has been crashing repeatedly with `unknown_error / null` in `create_security_update_pull_request.rb` for at least the last week (basic-ftp, icu-minify, ip-address, uuid). Root cause: pnpm 10.32.1 + lockfileVersion 9 hits known gaps in the hosted `dependabot-updater-npm` image's pnpm 10 support. We use Renovate for routine updates; security-update PRs from Dependabot would be redundant even if they worked.

The 30+ open security advisories are addressed in a separate PR (P1B) — this PR only stops the broken workflow noise.

## Test plan

- [ ] CI on this PR passes (Validate Template).
- [ ] After merge **and after the maintainer flips the repo-settings toggle**, no new \"Dependabot Updates\" failure runs appear on \`dev\` or \`prod\` over 48h.
- [ ] Dependabot **alerts** still appear in the Security tab (we keep those on).

Spec: vault/open-source/nextmedal/specs/2026-05-09-nextmedal-fix-all-and-100pct-coverage-design.md (P1A)