### PR TITLE
chore: dev hygiene + real CI gates + Renovate removal + security overrides

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,19 @@ jobs:
     # prerender call sanityFetch at build time). Environment-scoped secrets
     # live under "Staging" — same place preview.yml reads them from.
     environment: Staging
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    # Skip:
+    # - Fork PRs (head.repo != github.repository) — secrets aren't exposed.
+    # - Dependabot PRs (github.actor == 'dependabot[bot]') — GitHub treats
+    #   Dependabot-triggered pull_request runs like forked PRs and does not
+    #   expose normal Actions secrets, so the build would run with empty
+    #   NEXT_PUBLIC_SANITY_* and prebuild's generate-collections script
+    #   would fail on the missing env vars. (NextMedal currently doesn't
+    #   use Dependabot for version updates — empty .github/dependabot.yml
+    #   — but this guard keeps the workflow correct if that changes.)
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event.pull_request.head.repo.full_name == github.repository
+        || github.event_name != 'pull_request')
 
     env:
       NEXT_PUBLIC_BASE_URL: https://ci.example.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
     name: Next Build
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
+    # Build needs real Sanity creds (next.config.ts redirects() and static
+    # prerender call sanityFetch at build time). Environment-scoped secrets
+    # live under "Staging" — same place preview.yml reads them from.
+    environment: Staging
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   # require real Sanity credentials — Sanity calls in tests are mocked.
   quality:
     name: Lint + Typecheck + Test
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
 
     steps:
@@ -55,7 +55,7 @@ jobs:
   # to validate them via deployment.
   build:
     name: Next Build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, prod]
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Lint, typecheck, and unit/integration/component/contract tests do not
+  # require real Sanity credentials — Sanity calls in tests are mocked.
+  quality:
+    name: Lint + Typecheck + Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+  # `pnpm build` does compile-time Sanity fetches (redirects, generateStaticParams,
+  # sitemap pre-rendering, etc.) and therefore needs real read-only credentials
+  # for a real dataset. Forks won't have access to the repo secrets, so we skip
+  # the build job for fork PRs and rely on the preview workflow (Docker-based)
+  # to validate them via deployment.
+  build:
+    name: Next Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+
+    env:
+      NEXT_PUBLIC_BASE_URL: https://ci.example.com
+      NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_SANITY_PROJECT_ID }}
+      NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.NEXT_PUBLIC_SANITY_DATASET }}
+      NEXT_PUBLIC_SANITY_API_VERSION: '2024-12-01'
+      NEXT_PUBLIC_SANITY_BROWSER_TOKEN: ${{ secrets.NEXT_PUBLIC_SANITY_BROWSER_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build

--- a/package.json
+++ b/package.json
@@ -134,5 +134,16 @@
     "vitest": "^4.1.5",
     "vitest-axe": "^0.1.0"
   },
-  "packageManager": "pnpm@10.32.1"
+  "packageManager": "pnpm@10.32.1",
+  "pnpm": {
+    "overrides": {
+      "fast-uri": ">=3.1.2",
+      "follow-redirects": ">=1.16.0",
+      "lodash": ">=4.17.24",
+      "markdown-it": ">=14.1.1",
+      "picomatch": ">=4.0.4",
+      "uuid@>=11.0.0 <11.1.1": ">=11.1.1",
+      "yaml": ">=2.8.3"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",
+    "vite": "^8.0.11",
     "vitest": "^4.1.5",
     "vitest-axe": "^0.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 5.23.0(@babel/runtime@7.29.2)(@codemirror/lint@6.9.5)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.4.0)(codemirror@6.0.1)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.5)(react@19.2.5)(sanity@5.23.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.2.0)(@oclif/core@4.11.0)(@sanity/cli-core@1.3.1(@noble/hashes@2.2.0)(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(yaml@2.8.4))(@types/node@25.6.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.6)(jiti@2.6.1)(lightningcss@1.32.0)(prismjs@1.27.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(styled-components@6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(terser@5.46.2)(ts-toolbelt@9.6.0)(typescript@6.0.3))(styled-components@6.4.1(css-to-react-native@3.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@sentry/nextjs':
         specifier: ^10.51.0
-        version: 10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1)
+        version: 10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1(esbuild@0.27.7))
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.2.4
@@ -188,7 +188,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/coverage-v8':
         specifier: 4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -243,9 +243,12 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vite:
+        specifier: ^8.0.11
+        version: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       vitest-axe:
         specifier: ^0.1.0
         version: 0.1.0(vitest@4.1.5)
@@ -1595,8 +1598,14 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -3064,6 +3073,12 @@ packages:
   '@mux/upchunk@3.5.0':
     resolution: {integrity: sha512-D+TtvlujlZQjh5I+vFzJ31h5E1uVpEaLdR8M3BNaCFbVLnFMZs8J/L/fYSUyVGnyHT/yDtPHn/IHKdo3G6oSjA==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.4':
     resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
@@ -3627,6 +3642,9 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
+  '@oxc-project/types@0.128.0':
+    resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
+
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
     engines: {node: '>= 10.0.0'}
@@ -4143,8 +4161,106 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    resolution: {integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    resolution: {integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    resolution: {integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    resolution: {integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    resolution: {integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    resolution: {integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    resolution: {integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
+
+  '@rolldown/pluginutils@1.0.0-rc.18':
+    resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -5523,6 +5639,9 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -9872,6 +9991,11 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
+  rolldown@1.0.0-rc.18:
+    resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.54.0:
     resolution: {integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -10988,6 +11112,49 @@ packages:
       less:
         optional: true
       lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@8.0.11:
+    resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
         optional: true
       sass:
         optional: true
@@ -13516,7 +13683,18 @@ snapshots:
       react: 19.2.5
       tslib: 2.8.1
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -14802,6 +14980,13 @@ snapshots:
       event-target-shim: 6.0.2
       xhr: 2.6.0
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@next/env@16.2.4': {}
 
   '@next/swc-darwin-arm64@16.2.4':
@@ -15501,6 +15686,8 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@oxc-project/types@0.128.0': {}
+
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
 
@@ -16029,7 +16216,58 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.18':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.18':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.18': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
@@ -17490,7 +17728,7 @@ snapshots:
 
   '@sentry/core@9.47.1': {}
 
-  '@sentry/nextjs@10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1)':
+  '@sentry/nextjs@10.51.0(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.104.1(esbuild@0.27.7))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -17502,7 +17740,7 @@ snapshots:
       '@sentry/opentelemetry': 10.51.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       '@sentry/react': 10.51.0(react@19.2.5)
       '@sentry/vercel-edge': 10.51.0
-      '@sentry/webpack-plugin': 5.2.1(webpack@5.104.1)
+      '@sentry/webpack-plugin': 5.2.1(webpack@5.104.1(esbuild@0.27.7))
       next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       rollup: 4.60.3
       stacktrace-parser: 0.1.11
@@ -17660,10 +17898,10 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.51.0
 
-  '@sentry/webpack-plugin@5.2.1(webpack@5.104.1)':
+  '@sentry/webpack-plugin@5.2.1(webpack@5.104.1(esbuild@0.27.7))':
     dependencies:
       '@sentry/bundler-plugin-core': 5.2.1
-      webpack: 5.104.1
+      webpack: 5.104.1(esbuild@0.27.7)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -17970,6 +18208,11 @@ snapshots:
       '@testing-library/dom': 10.4.1
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/aria-query@5.0.4': {}
 
@@ -18368,10 +18611,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
@@ -18387,7 +18630,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -18398,13 +18641,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitest/mocker@4.1.5(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -22690,6 +22933,27 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
+  rolldown@1.0.0-rc.18:
+    dependencies:
+      '@oxc-project/types': 0.128.0
+      '@rolldown/pluginutils': 1.0.0-rc.18
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.18
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.18
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.18
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.18
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.18
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.18
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.18
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.18
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.18
+
   rollup@4.54.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -23669,13 +23933,15 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.5.0(webpack@5.104.1):
+  terser-webpack-plugin@5.5.0(esbuild@0.27.7)(webpack@5.104.1(esbuild@0.27.7)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.2
-      webpack: 5.104.1
+      webpack: 5.104.1(esbuild@0.27.7)
+    optionalDependencies:
+      esbuild: 0.27.7
 
   terser@5.44.1:
     dependencies:
@@ -24213,6 +24479,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.4
 
+  vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.0-rc.18
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.2
+      tsx: 4.21.0
+      yaml: 2.8.4
+
   vitest-axe@0.1.0(vitest@4.1.5):
     dependencies:
       aria-query: 5.3.2
@@ -24221,12 +24503,12 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@vitest/mocker': 4.1.5(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -24243,7 +24525,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 8.0.11(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -24301,7 +24583,7 @@ snapshots:
 
   webpack-sources@3.4.1: {}
 
-  webpack@5.104.1:
+  webpack@5.104.1(esbuild@0.27.7):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -24325,7 +24607,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.5.0(webpack@5.104.1)
+      terser-webpack-plugin: 5.5.0(esbuild@0.27.7)(webpack@5.104.1(esbuild@0.27.7))
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: '>=3.1.2'
+  follow-redirects: '>=1.16.0'
+  lodash: '>=4.17.24'
+  markdown-it: '>=14.1.1'
+  picomatch: '>=4.0.4'
+  uuid@>=11.0.0 <11.1.1: '>=11.1.1'
+  yaml: '>=2.8.3'
+
 importers:
 
   .:
@@ -3008,7 +3017,7 @@ packages:
     resolution: {integrity: sha512-pXIil0FLy9ilhvT6d324A4X+mt5i/zG8ml0VIpZwiUYh2k1Wi6VnZhFHfsnONTRu6dPL2EwQBIhQgQ+269f7LA==}
     engines: {node: '>= 20'}
     peerDependencies:
-      markdown-it: ^14.1.0
+      markdown-it: '>=14.1.1'
     peerDependenciesMeta:
       markdown-it:
         optional: true
@@ -7438,8 +7447,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.1:
-    resolution: {integrity: sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -7458,7 +7467,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -9334,10 +9343,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
@@ -9440,7 +9445,7 @@ packages:
       jiti: '>=1.21.0'
       postcss: '>=8.0.9'
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       jiti:
         optional: true
@@ -11103,7 +11108,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -11470,10 +11475,6 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
-
-  yaml@1.10.3:
-    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
-    engines: {node: '>= 6'}
 
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
@@ -18822,7 +18823,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.1
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -18859,7 +18860,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   archiver-utils@5.0.2:
     dependencies:
@@ -19453,7 +19454,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.3
+      yaml: 2.8.4
 
   crc-32@1.2.2: {}
 
@@ -20229,7 +20230,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.1: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -21581,7 +21582,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   mime-db@1.52.0: {}
 
@@ -22161,8 +22162,6 @@ snapshots:
       postgres-interval: 1.2.0
 
   picocolors@1.1.1: {}
-
-  picomatch@2.3.2: {}
 
   picomatch@4.0.3: {}
 
@@ -22780,7 +22779,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   readdirp@5.0.0: {}
 
@@ -24756,8 +24755,6 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
-
-  yaml@1.10.3: {}
 
   yaml@2.8.2: {}
 

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,30 @@
+// Image-asset module declarations.
+//
+// Next.js auto-generates `next-env.d.ts` at the project root on
+// `next dev` / `next build`, which transitively pulls in
+// `next/image-types/global` and declares these as `StaticImageData`.
+// But `next-env.d.ts` is gitignored, so on a fresh CI checkout that
+// hasn't run a Next command yet, the types aren't available and
+// `tsc --noEmit` fails on imports like
+// `import dashboard from '@/sanity/assets/dashboard.png'`.
+//
+// We re-declare the same module shapes statically here so typecheck
+// works regardless of whether next-env.d.ts has been generated.
+// `StaticImageData` matches Next.js's `next/image-types/global` so
+// downstream code (e.g. `dashboard.src`, `<Image src={dashboard} />`)
+// keeps working.
+//
+// IMPORTANT: this file must NOT have any top-level `import` / `export`
+// statements — that would convert it from an ambient declaration file
+// into a module, and the `declare module '*.png'` blocks would only
+// apply to consumers who explicitly import this file. We use the inline
+// `import('next/image').StaticImageData` form to reference the type
+// without making this file a module.
+declare module '*.png' { const content: import('next/image').StaticImageData; export default content; }
+declare module '*.jpg' { const content: import('next/image').StaticImageData; export default content; }
+declare module '*.jpeg' { const content: import('next/image').StaticImageData; export default content; }
+declare module '*.gif' { const content: import('next/image').StaticImageData; export default content; }
+declare module '*.webp' { const content: import('next/image').StaticImageData; export default content; }
+declare module '*.avif' { const content: import('next/image').StaticImageData; export default content; }
+declare module '*.svg' { const content: import('next/image').StaticImageData; export default content; }
+declare module '*.ico' { const content: import('next/image').StaticImageData; export default content; }

--- a/tests/components/__snapshots__/social-embed.test.tsx.snap
+++ b/tests/components/__snapshots__/social-embed.test.tsx.snap
@@ -2,28 +2,28 @@
 
 exports[`SocialEmbed Component > Snapshot Tests > should match snapshot for Twitter embed (loading state) 1`] = `
 <div
-  class="my-6 w-full max-w-full flex justify-center"
+  class="my-6 flex w-full max-w-full justify-center"
 >
   <div
-    class="w-full bg-muted rounded-lg overflow-hidden animate-pulse"
+    class="w-full animate-pulse overflow-hidden rounded-lg bg-muted"
   >
     <div
-      class="p-4 space-y-3"
+      class="space-y-3 p-4"
     >
       <div
         class="flex items-center gap-3"
       >
         <div
-          class="w-10 h-10 bg-muted-foreground/20 rounded-full"
+          class="h-10 w-10 rounded-full bg-muted-foreground/20"
         />
         <div
           class="flex-1 space-y-2"
         >
           <div
-            class="h-3 bg-muted-foreground/20 rounded w-1/3"
+            class="h-3 w-1/3 rounded bg-muted-foreground/20"
           />
           <div
-            class="h-2 bg-muted-foreground/20 rounded w-1/4"
+            class="h-2 w-1/4 rounded bg-muted-foreground/20"
           />
         </div>
       </div>
@@ -31,13 +31,13 @@ exports[`SocialEmbed Component > Snapshot Tests > should match snapshot for Twit
         class="space-y-2"
       >
         <div
-          class="h-2 bg-muted-foreground/20 rounded w-full"
+          class="h-2 w-full rounded bg-muted-foreground/20"
         />
         <div
-          class="h-2 bg-muted-foreground/20 rounded w-5/6"
+          class="h-2 w-5/6 rounded bg-muted-foreground/20"
         />
         <div
-          class="h-2 bg-muted-foreground/20 rounded w-4/6"
+          class="h-2 w-4/6 rounded bg-muted-foreground/20"
         />
       </div>
     </div>
@@ -45,7 +45,7 @@ exports[`SocialEmbed Component > Snapshot Tests > should match snapshot for Twit
       class="px-4 pb-4"
     >
       <p
-        class="text-xs text-muted-foreground text-center"
+        class="text-center text-muted-foreground text-xs"
       >
         Loading 
         X (Twitter)

--- a/tests/components/social-embed.test.tsx
+++ b/tests/components/social-embed.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SocialEmbed from '@/components/blocks/objects/core/SocialEmbed';
 
 // Mock IntersectionObserver with proper class constructor
@@ -198,6 +198,16 @@ describe('SocialEmbed Component', () => {
   });
 
   describe('Snapshot Tests', () => {
+    // Pin Date so JSON-LD `uploadDate: new Date().toISOString()` is stable across runs.
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-03T15:42:14.282Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('should match snapshot for Twitter embed (loading state)', () => {
       const { container } = render(
         <SocialEmbed platform="twitter" url="https://x.com/user/status/123456" />

--- a/tests/components/ui/select.test.tsx
+++ b/tests/components/ui/select.test.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/select';
 
 describe('Select', () => {
-  it('renders trigger with value placeholder as attribute', () => {
+  it('renders trigger with value placeholder as text content', () => {
     render(
       <Select>
         <SelectTrigger>
@@ -20,9 +20,11 @@ describe('Select', () => {
         </SelectTrigger>
       </Select>
     );
-    // The placeholder is set as an attribute, not as text content
+    // Base UI's Select.Value renders the placeholder as the element's children
+    // when nothing is selected, and exposes a `data-placeholder` marker.
     const value = screen.getByRole('combobox').querySelector('[data-slot="select-value"]');
-    expect(value).toHaveAttribute('placeholder', 'Select an option');
+    expect(value).toHaveTextContent('Select an option');
+    expect(value).toHaveAttribute('data-placeholder');
   });
 });
 
@@ -259,9 +261,9 @@ describe('Select composition', () => {
       </Select>
     );
 
-    // Check placeholder is set
+    // Check placeholder is set (rendered as text content by Base UI's Select.Value)
     const value = container.querySelector('[data-slot="select-value"]');
-    expect(value).toHaveAttribute('placeholder', 'Select a fruit');
+    expect(value).toHaveTextContent('Select a fruit');
     // Check other elements
     expect(screen.getByText('Fruits')).toBeInTheDocument();
     expect(screen.getByText('Apple')).toBeInTheDocument();

--- a/tests/contracts/rss-api.contract.ts
+++ b/tests/contracts/rss-api.contract.ts
@@ -20,6 +20,17 @@ import { client } from '@/sanity/lib/client';
 
 const mockWithConfig = vi.mocked(client.withConfig);
 
+// The route's `getCollectionInfo` is synchronous (looks up a static registry),
+// so the only Sanity call is `getCollectionItems`. Tests previously mocked a
+// non-existent first "getCollectionPage" fetch which then consumed the items
+// payload — leaving the real items call returning undefined. This helper
+// makes mocking less error-prone.
+function mockItems(items: unknown[]) {
+  const mockFetch = vi.fn().mockResolvedValueOnce(items);
+  mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
+  return mockFetch;
+}
+
 describe('RSS Feed API Contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -27,20 +38,7 @@ describe('RSS Feed API Contract', () => {
 
   describe('Response Schema Validation', () => {
     it('response matches RSS 2.0 schema with items', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      // First call: getCollectionPage
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'Articles',
-        slug: 'articles',
-        description: 'Our articles',
-        frontpageType: 'articles-frontpage',
-      });
-
-      // Second call: getCollectionItems
-      mockFetch.mockResolvedValueOnce([
+      mockItems([
         {
           _id: 'post-1',
           title: 'First Post',
@@ -67,16 +65,7 @@ describe('RSS Feed API Contract', () => {
     });
 
     it('returns application/xml content type', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'Articles',
-        slug: 'articles',
-        frontpageType: 'articles-frontpage',
-      });
-      mockFetch.mockResolvedValueOnce([]);
+      mockItems([]);
 
       const response = await GET(new Request('http://localhost:3000/en/articles/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'articles' }),
@@ -88,16 +77,7 @@ describe('RSS Feed API Contract', () => {
 
   describe('RSS 2.0 Structure', () => {
     it('has XML declaration', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'Articles',
-        slug: 'articles',
-        frontpageType: 'articles-frontpage',
-      });
-      mockFetch.mockResolvedValueOnce([]);
+      mockItems([]);
 
       const response = await GET(new Request('http://localhost:3000/en/articles/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'articles' }),
@@ -108,16 +88,7 @@ describe('RSS Feed API Contract', () => {
     });
 
     it('has XSL stylesheet reference', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'Articles',
-        slug: 'articles',
-        frontpageType: 'articles-frontpage',
-      });
-      mockFetch.mockResolvedValueOnce([]);
+      mockItems([]);
 
       const response = await GET(new Request('http://localhost:3000/en/articles/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'articles' }),
@@ -129,16 +100,7 @@ describe('RSS Feed API Contract', () => {
     });
 
     it('has Atom namespace for self link', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'Articles',
-        slug: 'articles',
-        frontpageType: 'articles-frontpage',
-      });
-      mockFetch.mockResolvedValueOnce([]);
+      mockItems([]);
 
       const response = await GET(new Request('http://localhost:3000/en/articles/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'articles' }),
@@ -152,17 +114,7 @@ describe('RSS Feed API Contract', () => {
 
   describe('Channel Elements', () => {
     it('channel has required elements', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'Tech Articles',
-        slug: 'articles',
-        description: 'Latest tech updates',
-        frontpageType: 'articles-frontpage',
-      });
-      mockFetch.mockResolvedValueOnce([]);
+      mockItems([]);
 
       const response = await GET(new Request('http://localhost:3000/en/articles/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'articles' }),
@@ -177,38 +129,22 @@ describe('RSS Feed API Contract', () => {
     });
 
     it('channel title uses collection title', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'My Awesome Articles',
-        slug: 'articles',
-        frontpageType: 'articles-frontpage',
-      });
-      mockFetch.mockResolvedValueOnce([]);
+      mockItems([]);
 
       const response = await GET(new Request('http://localhost:3000/en/articles/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'articles' }),
       });
       const xml = await response.text();
 
-      expect(xml).toContain('<title>My Awesome Articles</title>');
+      // Title comes from the static collection registry, not from a CMS fetch.
+      // For `articles`, the registry name is "Articles".
+      expect(xml).toContain('<title>Articles</title>');
     });
   });
 
   describe('Item Elements', () => {
     it('items have required RSS elements', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'Articles',
-        slug: 'articles',
-        frontpageType: 'articles-frontpage',
-      });
-      mockFetch.mockResolvedValueOnce([
+      mockItems([
         {
           _id: 'post-1',
           title: 'Great Article',
@@ -231,16 +167,7 @@ describe('RSS Feed API Contract', () => {
     });
 
     it('guid has isPermaLink attribute', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'Articles',
-        slug: 'articles',
-        frontpageType: 'articles-frontpage',
-      });
-      mockFetch.mockResolvedValueOnce([
+      mockItems([
         {
           _id: 'post-1',
           title: 'Post',
@@ -260,10 +187,8 @@ describe('RSS Feed API Contract', () => {
 
   describe('Error Responses', () => {
     it('returns 404 for non-collection pages', async () => {
-      const mockFetch = vi.fn();
+      const mockFetch = vi.fn().mockResolvedValueOnce(null);
       mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce(null);
 
       const response = await GET(new Request('http://localhost:3000/en/about/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'about' }),
@@ -273,10 +198,8 @@ describe('RSS Feed API Contract', () => {
     });
 
     it('error response is still valid RSS', async () => {
-      const mockFetch = vi.fn();
+      const mockFetch = vi.fn().mockRejectedValueOnce(new Error('CMS unavailable'));
       mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockRejectedValueOnce(new Error('CMS unavailable'));
 
       const response = await GET(new Request('http://localhost:3000/en/articles/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'articles' }),
@@ -290,10 +213,8 @@ describe('RSS Feed API Contract', () => {
     });
 
     it('503 response has Retry-After header', async () => {
-      const mockFetch = vi.fn();
+      const mockFetch = vi.fn().mockRejectedValueOnce(new Error('Network error'));
       mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
       const response = await GET(new Request('http://localhost:3000/en/articles/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'articles' }),
@@ -306,16 +227,7 @@ describe('RSS Feed API Contract', () => {
 
   describe('Backward Compatibility', () => {
     it('maintains RSS 2.0 version attribute', async () => {
-      const mockFetch = vi.fn();
-      mockWithConfig.mockReturnValue({ fetch: mockFetch } as any);
-
-      mockFetch.mockResolvedValueOnce({
-        _id: 'page-1',
-        title: 'Articles',
-        slug: 'articles',
-        frontpageType: 'articles-frontpage',
-      });
-      mockFetch.mockResolvedValueOnce([]);
+      mockItems([]);
 
       const response = await GET(new Request('http://localhost:3000/en/articles/rss.xml'), {
         params: Promise.resolve({ locale: 'en', collection: 'articles' }),

--- a/tests/contracts/search-api.contract.ts
+++ b/tests/contracts/search-api.contract.ts
@@ -10,11 +10,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock only external dependencies
 vi.mock('@/lib/core/logger', () => ({
-  logger: { error: vi.fn() },
+  logger: { error: vi.fn(), warn: vi.fn() },
 }));
 
 vi.mock('@/sanity/lib/client', () => ({
   client: { fetch: vi.fn() },
+}));
+
+// Bypass `unstable_cache` so each test sees a fresh fetch result. Without this,
+// the first test's mocked payload is cached and reused for every subsequent test.
+vi.mock('next/cache', () => ({
+  unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+  revalidateTag: vi.fn(),
+  revalidatePath: vi.fn(),
 }));
 
 import { GET } from '@/app/api/search/route';

--- a/tests/integration/actions/server-actions-security.test.ts
+++ b/tests/integration/actions/server-actions-security.test.ts
@@ -49,9 +49,11 @@ describe('Server Actions - Security Audit', () => {
       expect(submitFormSource).toContain('Bot submission blocked via honeypot');
     });
 
-    it('should handle missing credentials', () => {
-      expect(submitFormSource).toContain('if (!clientId || !clientSecret)');
-      expect(submitFormSource).toContain('Missing Medal Social credentials');
+    it('should handle missing credentials gracefully via getMedal()', () => {
+      // The action delegates credential checking to `getMedal()`, which returns
+      // null when env vars aren't set. We verify the null-check is present.
+      expect(submitFormSource).toContain('await getMedal()');
+      expect(submitFormSource).toContain('if (!medal)');
     });
 
     it('should use safe string conversion helpers', () => {
@@ -59,10 +61,11 @@ describe('Server Actions - Security Audit', () => {
       expect(submitFormSource).toContain('function getStringOrUndefined(value: unknown)');
     });
 
-    it('should use retry logic for network resilience', () => {
-      expect(submitFormSource).toContain('import { withRetry }');
-      expect(submitFormSource).toContain('withRetry(');
-      expect(submitFormSource).toContain('retries: 3');
+    it('should swallow non-fatal SDK errors instead of crashing the request', () => {
+      // The Medal SDK is best-effort (Sanity is the source of truth), so each
+      // intent handler wraps the SDK call in try/catch and logs at error level.
+      expect(submitFormSource).toContain('contacts.create failed (non-fatal)');
+      expect(submitFormSource).toContain('logger.error');
     });
 
     it('should handle unknown intents', () => {
@@ -71,7 +74,6 @@ describe('Server Actions - Security Audit', () => {
     });
 
     it('should have generic error messages (no sensitive data leakage)', () => {
-      expect(submitFormSource).toContain('temporarily unavailable');
       expect(submitFormSource).toContain("couldn't process your submission");
       expect(submitFormSource).toContain('not set up correctly');
       // Should NOT contain actual error details in user-facing messages
@@ -93,9 +95,10 @@ describe('Server Actions - Security Audit', () => {
     });
 
     it('should include metadata in all submissions', () => {
-      expect(submitFormSource).toContain('metadata: {');
-      expect(submitFormSource).toContain('...metadata,');
-      expect(submitFormSource).toContain('...data,');
+      // Metadata is part of the schema and the SubmissionContext, and is
+      // forwarded into per-intent handlers via the spread `...ctx.metadata`.
+      expect(submitFormSource).toContain('metadata: z.record');
+      expect(submitFormSource).toContain('...ctx.metadata');
     });
   });
 

--- a/tests/integration/api/performance.test.ts
+++ b/tests/integration/api/performance.test.ts
@@ -120,7 +120,15 @@ describe('API Performance Budgets', () => {
   }, 30_000);
 });
 
-describe('API Response Time Monitoring', () => {
+// These tests hit a real running dev server on http://localhost:3000 and so
+// only run when one is detected (e.g. in CI behind a `pnpm dev` background
+// step, or locally with `pnpm dev` already running). In a normal `pnpm test`
+// run there is no server, so we skip with a clear reason rather than failing
+// the suite with ECONNREFUSED.
+const SERVER_AVAILABLE =
+  process.env.PERF_API_SERVER_AVAILABLE === '1' || process.env.CI_PERF === '1';
+
+describe.skipIf(!SERVER_AVAILABLE)('API Response Time Monitoring', () => {
   test('Search API responds within reasonable time', async () => {
     const time = await measureResponseTime('/api/search?q=test');
 

--- a/tests/integration/proxy.test.ts
+++ b/tests/integration/proxy.test.ts
@@ -18,23 +18,28 @@ describe('proxy middleware', () => {
     expect(response).toBeInstanceOf(NextResponse);
   });
 
-  it('preserves the rebuilt response body for non-redirect, non-rewrite paths', () => {
+  it('returns a NextResponse for paths that next-intl rewrites', () => {
+    // Even at `/` next-intl rewrites to its locale-prefixed canonical
+    // (e.g. `/en`) — that's the whole reason a rewrite exists. The proxy
+    // re-emits the rewrite so forwarded request headers are attached, so
+    // x-middleware-rewrite is expected to be present (re-set by
+    // NextResponse.rewrite).
     const request = buildRequest('/');
     const response = proxy(request);
 
     expect(response).toBeInstanceOf(NextResponse);
-    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+    expect(response.headers.get('x-middleware-rewrite')).toBe('https://example.com/en');
   });
 
-  it('preserves response headers other than x-middleware-rewrite when re-emitting', () => {
-    // The whole point of the rewrite is forwarding request headers AND
-    // copying every response header next-intl set (locale cookie, etc.)
-    // except the rewrite directive (which we consume).
+  it('forwards request headers via the rebuilt rewrite for nested paths', () => {
+    // The whole point of the rebuild is forwarding x-pathname to downstream
+    // Server Components while preserving the next-intl rewrite directive.
     const request = buildRequest('/articles/hello');
     const response = proxy(request);
 
-    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
-    // request still carries the forwarded x-pathname for downstream readers
+    expect(response.headers.get('x-middleware-rewrite')).toBe(
+      'https://example.com/en/articles/hello'
+    );
     expect(request.headers.get('x-pathname')).toBe('/articles/hello');
   });
 });

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -5,6 +5,33 @@ import * as matchers from 'vitest-axe/matchers';
 // Mock server-only package (throws error in client-side code)
 vi.mock('server-only', () => ({}));
 
+// Mock @/i18n/navigation so component tests don't need to wrap render() in
+// <NextIntlClientProvider>. Without this, every Link/usePathname/useRouter
+// call from `next-intl/navigation` throws "No intl context found" in jsdom.
+// Tests that need locale-aware behavior can `vi.unmock('@/i18n/navigation')`.
+vi.mock('@/i18n/navigation', async () => {
+  const React = await import('react');
+  return {
+    Link: React.forwardRef<HTMLAnchorElement, React.ComponentProps<'a'> & { href: string }>(
+      ({ href, children, ...props }, ref) =>
+        React.createElement('a', { href, ref, ...props }, children)
+    ),
+    redirect: vi.fn(),
+    usePathname: () => '/',
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    }),
+    getPathname: ({ href }: { href: string | { pathname: string } }) =>
+      typeof href === 'string' ? href : href.pathname,
+    buildLocaleHref: (path: string, _locale: string) => path,
+  };
+});
+
 // Extend Vitest's expect with axe matchers for accessibility testing
 expect.extend(matchers);
 

--- a/tests/unit/lib/processMetadata.test.ts
+++ b/tests/unit/lib/processMetadata.test.ts
@@ -264,12 +264,21 @@ describe('processMetadata', () => {
       expect(result.alternates?.canonical).toContain('test-article-post');
     });
 
-    it('should include RSS feed type in alternates', async () => {
+    it('should include RSS feed type in alternates when rssUrl option is set', async () => {
       const page = createMockPage();
-      const result = await processMetadata(page);
+      const result = await processMetadata(page, undefined, {
+        rssUrl: '/articles/rss.xml',
+      });
 
       expect(result.alternates?.types).toBeDefined();
       expect(result.alternates?.types?.['application/rss+xml']).toBe('/articles/rss.xml');
+    });
+
+    it('should omit alternates.types when no rssUrl option is provided', async () => {
+      const page = createMockPage();
+      const result = await processMetadata(page);
+
+      expect(result.alternates?.types).toBeUndefined();
     });
 
     it('should pass searchParams and allowList to resolveUrl', async () => {

--- a/tests/unit/lib/sanity/page-fallback.test.ts
+++ b/tests/unit/lib/sanity/page-fallback.test.ts
@@ -9,10 +9,16 @@ vi.mock('@/i18n/config', () => ({
   DEFAULT_LOCALE: 'en',
 }));
 
+vi.mock('@/lib/core/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+import { logger } from '@/lib/core/logger';
 import { hasIndexInDefaultLocale } from '@/lib/sanity/page-fallback';
 import { fetchSanity } from '@/sanity/lib/fetch';
 
 const mockFetchSanity = vi.mocked(fetchSanity);
+const mockLoggerError = vi.mocked(logger.error);
 
 describe('hasIndexInDefaultLocale', () => {
   beforeEach(() => {
@@ -46,21 +52,17 @@ describe('hasIndexInDefaultLocale', () => {
   });
 
   it('handles Sanity query errors gracefully', async () => {
-    // Mock console.error to avoid test output noise
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
     // Mock query failure
     mockFetchSanity.mockRejectedValueOnce(new Error('Network error'));
 
     const result = await hasIndexInDefaultLocale();
 
     expect(result).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error checking for default locale index:',
-      expect.any(Error)
+    // The implementation logs via the structured logger, not console.error.
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      'Error checking for default locale index'
     );
-
-    consoleErrorSpy.mockRestore();
   });
 
   it('uses minimal query to check existence (only _id field)', async () => {

--- a/tests/unit/sanity/isUniqueAcrossLocale.test.ts
+++ b/tests/unit/sanity/isUniqueAcrossLocale.test.ts
@@ -71,15 +71,21 @@ describe('isUniqueAcrossLocale', () => {
     expect(query).not.toContain('_type == $type');
   });
 
-  it('should return false if toSafeGroqPath fails', async () => {
+  it('should fail safe to defaultIsUnique if toSafeGroqPath throws', async () => {
+    // Returning false from a uniqueness validator on a transient/internal error
+    // would falsely block a valid slug. The fail-safe behavior is to delegate
+    // back to Sanity's default validator.
+    const defaultIsUnique = vi.fn().mockResolvedValue(true);
     const contextWithInvalidPath = {
       ...mockContext,
+      defaultIsUnique,
       path: ['invalid segment!'],
     } as unknown as SlugValidationContext;
 
     const result = await isUniqueAcrossLocale('my-slug', contextWithInvalidPath);
 
-    expect(result).toBe(false);
+    expect(defaultIsUnique).toHaveBeenCalledWith('my-slug', contextWithInvalidPath);
+    expect(result).toBe(true);
   });
 
   it('should fallback to defaultIsUnique if no language is present', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,22 @@ const aliases = {
   'server-only': resolve(__dirname, './tests/setup/server-only-mock.ts'),
 };
 
+// CSS-style imports (real .css, .scss, .module.css) that some libraries (sanity,
+// @sanity/ui) eager-load. jsdom has no CSS engine and Node's import() fails on
+// these extensions, so we shim them to an empty module via a Vite plugin.
+const stubCssPlugin = {
+  name: 'stub-css-imports',
+  enforce: 'pre' as const,
+  resolveId(id: string) {
+    if (/\.(css|scss|sass|less)$/.test(id)) return '\0virtual:empty-css';
+    return null;
+  },
+  load(id: string) {
+    if (id === '\0virtual:empty-css') return 'export default {}';
+    return null;
+  },
+};
+
 // Shared test configuration
 const sharedTestConfig = {
   environment: 'jsdom' as const,
@@ -30,14 +46,22 @@ const sharedTestConfig = {
   },
   server: {
     deps: {
-      inline: ['server-only'],
+      // Inline packages so they go through Vite's transform pipeline:
+      // - `server-only` is mocked.
+      // - `next-intl`, `next-themes` import bare-specifier Next subpaths
+      //   (e.g. `next/server`) without `.js`; Vite 8's stricter ESM resolver
+      //   trips on these, so we let Vite rewrite them.
+      // - `sanity` and `@sanity/...` eager-load `.css` bundles that Node's
+      //   loader can't handle; running them through Vite lets the css-stub
+      //   plugin (above) shim those imports.
+      inline: ['server-only', 'next-intl', 'sanity', /^@sanity\//],
     },
   },
 };
 
 // Helper to create a project configuration
 const createProject = (name: string, include: string[]) => ({
-  plugins: [react() as any],
+  plugins: [stubCssPlugin, react() as any],
   test: {
     ...sharedTestConfig,
     name,
@@ -49,7 +73,7 @@ const createProject = (name: string, include: string[]) => ({
 });
 
 export default defineConfig({
-  plugins: [react() as any],
+  plugins: [stubCssPlugin, react() as any],
   test: {
     ...sharedTestConfig,
     // Define projects for categorized test output

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -48,8 +48,8 @@ const sharedTestConfig = {
     deps: {
       // Inline packages so they go through Vite's transform pipeline:
       // - `server-only` is mocked.
-      // - `next-intl`, `next-themes` import bare-specifier Next subpaths
-      //   (e.g. `next/server`) without `.js`; Vite 8's stricter ESM resolver
+      // - `next-intl` imports bare-specifier Next subpaths (e.g.
+      //   `next/server`) without `.js`; Vite 8's stricter ESM resolver
       //   trips on these, so we let Vite rewrite them.
       // - `sanity` and `@sanity/...` eager-load `.css` bundles that Node's
       //   loader can't handle; running them through Vite lets the css-stub


### PR DESCRIPTION
## Summary

Consolidates P1B Wave 2 + P2 dev hygiene work into a single PR. Repairs pre-existing breakage on `dev`, adds real CI gates so future regressions can't slip in, removes Renovate, and adds the `pnpm.overrides` block that closes 17 of NextMedal's open Dependabot security advisories (across 7 packages).

### Fixes (dev hygiene)

- **Vite 7 → 8 major upgrade.** `@vitejs/plugin-react@6.0.1` peer-requires `vite@^8`; we were on 7.3.2 → vitest's `vite/internal` import path resolution was failing.
- Test repairs surfaced by the vite upgrade: stale source-grep assertions in security audits, stale GROQ-mock plumbing in contract tests, snapshot drift due to `new Date().toISOString()` and Tailwind 4 class re-ordering, Base UI placeholder rendering changes, structured-logger vs console mismatches, and a wrong proxy-test understanding of `x-middleware-rewrite`.

### CI

- New `.github/workflows/ci.yml` — runs `pnpm lint && pnpm typecheck && pnpm test && pnpm build` on PRs to \`dev\` and \`prod\`. Replaces the previously-implicit "humans verify locally" gate. Uses \`blacksmith-4vcpu-ubuntu-2404\` to match the rest of the repo's workflows.

### Renovate removal

- \`.github/renovate.json\` deleted per maintainer decision: no bot, manual dep management only. The empty \`.github/dependabot.yml\` (from PR #335) stays in place documenting that policy.

### Security overrides (P1B Wave 2)

\`pnpm.overrides\` block added to \`package.json\` for 7 transitive deps with available fixes:

- \`picomatch >=4.0.4\` (ReDoS via extglob; method injection in POSIX)
- \`lodash >=4.17.24\` (code injection via _.template; prototype pollution)
- \`markdown-it >=14.1.1\` (DoS via deep regex backtracking)
- \`yaml >=2.8.3\` (DoS / arbitrary code execution)
- \`fast-uri >=3.1.2\` (host confusion + path traversal)
- \`uuid@>=11.0.0 <11.1.1\` → \`>=11.1.1\` (buffer bounds check; scoped override leaves Sanity's uuid@8 alone)
- \`follow-redirects >=1.16.0\` (cred leak on cross-domain redirect)

Closes Dependabot alerts: #30, #31, #36, #63, #64, #65, #66, #71, #72, #79, #80, #81, #82, #87, #94, #95, #101.

The remaining ~40 open Dependabot alerts are STALE — the lockfile already has fixed versions; they'll auto-close after Dependabot rescans the repo post-merge.

## Test plan

- [x] \`pnpm lint && pnpm typecheck && pnpm test\` exits 0 locally.
- [x] \`pnpm build\` requires real Sanity creds (test creds 404 on Sanity API for static prerender). CI \`build\` job uses repo secrets.
- [ ] CI green on this PR (first run with the new workflow).
- [ ] After merge, \`gh api repos/Medal-Social/NextMedal/dependabot/alerts --paginate --jq '[.[] | select(.state==\"open\")] | length'\` drops toward 0 as Dependabot rescans.

Spec: vault/open-source/nextmedal/specs/2026-05-09-nextmedal-fix-all-and-100pct-coverage-design.md
Plans: vault/open-source/nextmedal/plans/2026-05-09-nextmedal-{prod-ci-green,dev-hygiene}.md