### PR TITLE
chore: remove remaining Sentry deployment references

### DIFF
--- a/.changeset/calm-security-patches.md
+++ b/.changeset/calm-security-patches.md
@@ -2,4 +2,4 @@
 "@medalsocial/nextmedal": patch
 ---
 
-Patch Next.js and Mermaid to close current security advisories, and remove NextMedal's first-party Sentry integration.
+Patch Next.js and Mermaid to close current security advisories, and remove NextMedal's first-party error monitoring integration.

--- a/.env.example
+++ b/.env.example
@@ -39,12 +39,6 @@ NEXT_PUBLIC_SANITY_BROWSER_TOKEN=
 # NEXT_PUBLIC_UMAMI_SCRIPT_URL=
 # NEXT_PUBLIC_UMAMI_WEBSITE_ID=
 
-# Sentry Error Monitoring (only active in production)
-# NEXT_PUBLIC_SENTRY_DSN=
-# SENTRY_ORG=
-# SENTRY_PROJECT=
-# SENTRY_AUTH_TOKEN=
-
 # ====================
 # ADVANCED (OPTIONAL)
 # ====================

--- a/.github/workflows/container-app.yaml
+++ b/.github/workflows/container-app.yaml
@@ -30,12 +30,6 @@ properties:
         value: "${NEXT_PUBLIC_UMAMI_WEBSITE_ID}"
       - name: NEXT_PUBLIC_APP_ENV
         value: "${NEXT_PUBLIC_APP_ENV}"
-      - name: NEXT_PUBLIC_SENTRY_DSN
-        value: "${NEXT_PUBLIC_SENTRY_DSN}"
-      - name: SENTRY_ORG
-        value: "${SENTRY_ORG}"
-      - name: SENTRY_PROJECT
-        value: "${SENTRY_PROJECT}"
       probes:
       - type: liveness
         httpGet:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -55,12 +55,8 @@ jobs:
             NEXT_PUBLIC_UMAMI_SCRIPT_URL=${{ secrets.NEXT_PUBLIC_UMAMI_SCRIPT_URL }}
             NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ secrets.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}
             NEXT_PUBLIC_APP_ENV=${{ secrets.NEXT_PUBLIC_APP_ENV }}
-            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
-            SENTRY_ORG=${{ secrets.SENTRY_ORG }}
-            SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}
           secrets: |
             NEXT_PUBLIC_SANITY_BROWSER_TOKEN=${{ secrets.NEXT_PUBLIC_SANITY_BROWSER_TOKEN }}
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Azure Login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
@@ -80,9 +76,6 @@ jobs:
           NEXT_PUBLIC_UMAMI_SCRIPT_URL: ${{ secrets.NEXT_PUBLIC_UMAMI_SCRIPT_URL }}
           NEXT_PUBLIC_UMAMI_WEBSITE_ID: ${{ secrets.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}
           NEXT_PUBLIC_APP_ENV: ${{ secrets.NEXT_PUBLIC_APP_ENV }}
-          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           RESOURCE_GROUP: ${{ secrets.RESOURCE_GROUP }}
         run: |
           envsubst < .github/workflows/container-app.yaml > /tmp/deploy.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,6 @@ openspec
 
 dist
 
-# Sentry Config File
-.env.sentry-build-plugin
 .sanity
 
 # Collection templates (local reference only)


### PR DESCRIPTION
## Summary

- Remove remaining hidden/config Sentry references from production deployment files.
- Clean `.env.example`, Azure Container Apps workflow/env config, `.gitignore`, and the security changeset wording.

## Verification

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test --project=unit` (31 files / 588 tests)
- [x] `rg --hidden -n -i sentry|@sentry|SENTRY . -g '!node_modules' -g '!.next' -g '!test-results' -g '!coverage' -g '!pnpm-lock.yaml' -g '!.git'` returns no repo-owned references
- [x] Dependabot alerts: 0 open
- [x] Code scanning alerts: 0 open
- [x] Secret scanning alerts: 0 open