### PR TITLE
feat: adopt TanStack Intent — bump @medalsocial/sdk to 1.2.1, wire AGENTS.md

### DIFF
--- a/.github/workflows/intent-sync.yml
+++ b/.github/workflows/intent-sync.yml
@@ -1,0 +1,59 @@
+# intent-sync.yml — PR freshness gate for AGENTS.md.
+#
+# Runs `pnpm intent` (which invokes `@tanstack/intent install`) and
+# fails the PR if AGENTS.md ends up different from the committed
+# version. Forces contributors to regenerate the intent-managed block
+# whenever a dependency that ships agent skills (e.g. @medalsocial/sdk)
+# is bumped — otherwise AGENTS.md silently drifts from what consumers
+# of the cloned template will see after running `pnpm intent` locally.
+#
+# The check intentionally runs on every PR (not path-filtered): an SDK
+# bump on its own may not touch AGENTS.md, but the freshness check
+# still must run because the underlying skill content could have
+# changed.
+
+name: intent-sync
+
+on:
+  pull_request:
+    branches: [dev, prod]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-agents-md:
+    name: AGENTS.md is in sync with installed skills
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Regenerate intent-managed block
+        run: pnpm intent
+
+      - name: Fail if AGENTS.md drifted
+        run: |
+          if ! git diff --exit-code AGENTS.md; then
+            echo "::error::AGENTS.md is out of sync with installed intent-enabled dependencies."
+            echo "::error::Run 'pnpm intent' locally and commit the result."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- intent-skills:start -->
+## Skill Loading
+
+Before substantial work:
+- Skill check: run `pnpm dlx @tanstack/intent@latest list`, or use skills already listed in context.
+- Skill guidance: if one local skill clearly matches the task, run `pnpm dlx @tanstack/intent@latest load <package>#<skill>` and follow the returned `SKILL.md`.
+- Monorepos: when working across packages, run the skill check from the workspace root and prefer the local skill for the package being changed.
+- Multiple matches: prefer the most specific local skill for the package or concern you are changing; load additional skills only when the task spans multiple packages or concerns.
+<!-- intent-skills:end -->

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -68,7 +68,12 @@ cd NextMedal
 
 # Install dependencies
 pnpm install
+
+# Pull agent skills from dependencies (writes AGENTS.md)
+pnpm intent
 ```
+
+The `pnpm intent` step runs [`@tanstack/intent install`](https://tanstack.com/intent), which writes a small managed block to `AGENTS.md` instructing your AI coding agent (Claude Code, Cursor, Copilot, etc.) how to discover and load skills shipped by your dependencies (e.g. `@medalsocial/sdk` ships skills for the `Medal` client + resources). Re-run after bumping any intent-enabled dependency.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "@medalsocial/sdk": "^1.1.5",
+    "@medalsocial/sdk": "^1.2.1",
     "@mux/mux-player": "^3.13.0",
     "@mux/mux-player-react": "^3.13.0",
     "@sanity/asset-utils": "^2.3.0",
@@ -104,6 +104,7 @@
     "@sanity/language-filter": "^5.0.1",
     "@sanity/template-validator": "^3.1.0",
     "@tailwindcss/typography": "^0.5.19",
+    "@tanstack/intent": "0.0.41",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "clean": "rimraf .next ",
+    "intent": "tsx scripts/setup.ts",
     "dev": "next dev",
     "prebuild": "pnpm generate:collections",
     "build": "next build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@medalsocial/sdk':
-        specifier: ^1.1.5
-        version: 1.1.5
+        specifier: ^1.2.1
+        version: 1.2.1
       '@mux/mux-player':
         specifier: ^3.13.0
         version: 3.13.0(react@19.2.5)
@@ -177,6 +177,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.4)
+      '@tanstack/intent':
+        specifier: 0.0.41
+        version: 0.0.41
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -3005,8 +3008,8 @@ packages:
       markdown-it:
         optional: true
 
-  '@medalsocial/sdk@1.1.5':
-    resolution: {integrity: sha512-3LtQIU/4qhCo/POdLK6Xw7qkiNH0tdejHnpKpuAp/eF21sMQBlHUjYOqCIMwsSN2fvXhlt5qqWq+mXP1ie2VaA==}
+  '@medalsocial/sdk@1.2.1':
+    resolution: {integrity: sha512-gscHR9b9aR9ASudQlSZtAnUX0Sx4C5hPHaMjONhxH48dEglPF0zJC1qMJwLjxpgjKZrmiCV64iwVD5i8aA/Xgg==}
     engines: {node: '>=24'}
 
   '@mermaid-js/parser@1.1.1':
@@ -5220,6 +5223,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/intent@0.0.41':
+    resolution: {integrity: sha512-Psl+oDiidLvtctswkTQ1P6sQIihwrMLcdfQVfkLpO42oKwxWEr1lodWUHiOG5jFXsGwDDvpUv/WAdlmJF+yGpw==}
+    hasBin: true
 
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
@@ -10020,6 +10027,9 @@ packages:
   third-party-web@0.29.0:
     resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
 
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
+
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
@@ -14266,7 +14276,7 @@ snapshots:
     optionalDependencies:
       markdown-it: 14.1.1
 
-  '@medalsocial/sdk@1.1.5':
+  '@medalsocial/sdk@1.2.1':
     dependencies:
       zod: 3.25.76
 
@@ -14882,7 +14892,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.64':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@pinojs/redact@0.4.0': {}
 
@@ -17057,6 +17067,13 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/intent@0.0.41':
+    dependencies:
+      cac: 6.7.14
+      jsonc-parser: 3.3.1
+      semver: 7.7.4
+      yaml: 2.8.4
 
   '@tanstack/react-table@8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -22640,6 +22657,8 @@ snapshots:
       - react-native-b4a
 
   third-party-web@0.29.0: {}
+
+  third-party-web@0.29.2: {}
 
   thread-stream@4.0.0:
     dependencies:

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env tsx
+/**
+ * Post-clone setup: pull agent skills from installed dependencies.
+ *
+ * Runs `npx @tanstack/intent install`, which writes a small managed
+ * block to AGENTS.md instructing your AI coding agent (Claude Code,
+ * Cursor, Copilot, etc.) how to discover and load skills shipped by
+ * the npm packages you depend on.
+ *
+ * Idempotent — safe to re-run after bumping any intent-enabled
+ * dependency (e.g. @medalsocial/sdk, @medalsocial/meda).
+ */
+import { execSync } from "node:child_process";
+
+const run = (cmd: string): void => {
+  console.log(`> ${cmd}`);
+  execSync(cmd, { stdio: "inherit" });
+};
+
+console.log("Setting up NextMedal — pulling agent skills from dependencies...\n");
+run("npx --yes @tanstack/intent install");
+
+console.log("\n✓ Done. AGENTS.md now contains skill-loading guidance for your agent.");
+console.log("  Re-run `pnpm intent` after bumping any intent-enabled dependency.");

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -10,15 +10,15 @@
  * Idempotent — safe to re-run after bumping any intent-enabled
  * dependency (e.g. @medalsocial/sdk, @medalsocial/meda).
  */
-import { execSync } from "node:child_process";
+import { execSync } from 'node:child_process';
 
 const run = (cmd: string): void => {
   console.log(`> ${cmd}`);
-  execSync(cmd, { stdio: "inherit" });
+  execSync(cmd, { stdio: 'inherit' });
 };
 
-console.log("Setting up NextMedal — pulling agent skills from dependencies...\n");
-run("npx --yes @tanstack/intent install");
+console.log('Setting up NextMedal — pulling agent skills from dependencies...\n');
+run('npx --yes @tanstack/intent install');
 
-console.log("\n✓ Done. AGENTS.md now contains skill-loading guidance for your agent.");
-console.log("  Re-run `pnpm intent` after bumping any intent-enabled dependency.");
+console.log('\n✓ Done. AGENTS.md now contains skill-loading guidance for your agent.');
+console.log('  Re-run `pnpm intent` after bumping any intent-enabled dependency.');

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -2,13 +2,18 @@
 /**
  * Post-clone setup: pull agent skills from installed dependencies.
  *
- * Runs `npx @tanstack/intent install`, which writes a small managed
- * block to AGENTS.md instructing your AI coding agent (Claude Code,
- * Cursor, Copilot, etc.) how to discover and load skills shipped by
- * the npm packages you depend on.
+ * Runs the locally-pinned `@tanstack/intent` via `pnpm exec`, which
+ * writes a small managed block to AGENTS.md instructing your AI
+ * coding agent (Claude Code, Cursor, Copilot, etc.) how to discover
+ * and load skills shipped by the npm packages you depend on.
  *
  * Idempotent — safe to re-run after bumping any intent-enabled
  * dependency (e.g. @medalsocial/sdk, @medalsocial/meda).
+ *
+ * Uses `pnpm exec` (NOT `npx`) so the locked devDependency version
+ * runs every time. Bypassing the lockfile via `npx` would make
+ * AGENTS.md output non-deterministic across environments and break
+ * the `intent-sync` CI gate with drift unrelated to repo changes.
  */
 import { execSync } from 'node:child_process';
 
@@ -18,7 +23,7 @@ const run = (cmd: string): void => {
 };
 
 console.log('Setting up NextMedal — pulling agent skills from dependencies...\n');
-run('npx --yes @tanstack/intent install');
+run('pnpm exec intent install');
 
 console.log('\n✓ Done. AGENTS.md now contains skill-loading guidance for your agent.');
 console.log('  Re-run `pnpm intent` after bumping any intent-enabled dependency.');


### PR DESCRIPTION
## Summary

Adopts [TanStack Intent](https://tanstack.com/intent) on the **consumer** side. Cloners of this template now get auto-discovered agent-skill guidance from any intent-enabled dependency they install — starting with `@medalsocial/sdk@1.2.1` (which ships skills for the `Medal` class + all resources). If the consumer later adds `@medalsocial/meda`, its three skills (brand, shell, components) get picked up automatically too — no template change needed.

## What changed

- `package.json`
  - `@medalsocial/sdk`: `^1.1.5` → `^1.2.1` (first version with `skills/`)
  - `@tanstack/intent@0.0.41` added as devDep (exact pin — alpha CLI)
  - new `pnpm intent` script wired to `scripts/setup.ts`
- `scripts/setup.ts` — runs `npx --yes @tanstack/intent install`. Idempotent.
- `AGENTS.md` (new) — seeded by the first `pnpm intent` run. Small managed block instructing the AI agent to discover/load skills via Intent's CLI. `CLAUDE.md` is untouched.
- `QUICKSTART.md` — adds the `pnpm intent` step right after `pnpm install`, with one paragraph explaining what AGENTS.md is.
- `.github/workflows/intent-sync.yml` — fails any PR where `pnpm intent` produces a diff against the committed AGENTS.md, so contributors must regen when an intent-enabled dep bumps.

## Why `pnpm intent` (not `pnpm setup`)

`pnpm setup` collides with pnpm's built-in shell-PATH setup command and silently runs the wrong thing. `pnpm intent` is unambiguous and the alias appears in `package.json` scripts where consumers will find it.

## Why AGENTS.md and not CLAUDE.md

Intent's `install` CLI defaults to AGENTS.md when no agent config exists, which is cleaner here: NextMedal's 22 KB hand-curated CLAUDE.md stays the operator's primary playbook; AGENTS.md is a small, fully-managed file the freshness gate watches.

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm intent` writes AGENTS.md
- [x] Second run of `pnpm intent` produces no diff (idempotent)
- [x] `npx @tanstack/intent list` shows `@medalsocial/sdk` (2 skills) + `dotenv` (2 skills)
- [ ] `intent-sync` CI gate fires green on this PR
- [ ] Existing CI workflows (CI, validate, etc.) unaffected

## Source

- Spec: https://github.com/Medal-Social/Vault/blob/prod/vault/open-source/intent-adoption/specs/2026-05-24-intent-adoption-design.md
- Plan: https://github.com/Medal-Social/Vault/blob/prod/vault/open-source/intent-adoption/plans/2026-05-25-intent-adoption.md
- Producers: `@medalsocial/sdk@1.2.1` (https://github.com/Medal-Social/MedalSocial-SDK/pull/69), `@medalsocial/meda@2.4.2` (https://github.com/Medal-Social/meda/pull/167)