### PR TITLE
fix(social-share): refresh share URL on client-side route change

### DIFF
--- a/.changeset/social-share-route-refresh.md
+++ b/.changeset/social-share-route-refresh.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/nextmedal": patch
+---
+
+Fix the article/newsletter social-share buttons sharing the previous page's URL after client-side navigation between detail pages. The share URL now recomputes from the current pathname on each route change.

--- a/src/components/blocks/modules/frontpage/articles/SocialShare.tsx
+++ b/src/components/blocks/modules/frontpage/articles/SocialShare.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Check, Link } from 'lucide-react';
+import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
@@ -20,16 +21,20 @@ export default function SocialShare({
   className?: string;
 }) {
   const t = useTranslations('article');
+  const pathname = usePathname();
   const [copied, setCopied] = useState(false);
   // Default to empty string on server to match initial client state
   const [url, setUrl] = useState('');
 
   useEffect(() => {
-    // Share the current article URL. The page is already locale-prefixed and at
-    // the correct `/[collection]/[slug]` route, so use the live pathname directly
-    // rather than hardcoding an `/articles/` segment that doesn't match the route.
-    setUrl(`${window.location.origin}${window.location.pathname}`);
-  }, []);
+    // Share the current article URL. The pathname is already locale-prefixed and
+    // at the correct `/[collection]/[slug]` route, so use it directly rather than
+    // hardcoding an `/articles/` segment that doesn't match the route. Reading the
+    // reactive pathname (not window.location) also refreshes the URL when
+    // navigating client-side between detail pages, where this component is
+    // reconciled in place rather than remounted.
+    setUrl(`${window.location.origin}${pathname}`);
+  }, [pathname]);
 
   const handleCopy = async () => {
     const success = await copyToClipboard(url);


### PR DESCRIPTION
Follow-up fix for Codex review feedback on #344.

When navigating client-side between two article/newsletter detail pages, `SocialShare` is reconciled in place (not remounted), but its URL effect had an empty dependency array — so the share/copy buttons kept pointing at the previous page's URL while the title updated.

Build the share URL from the reactive `usePathname()` value and depend on it, so it recomputes on each navigation. `pnpm lint`, `pnpm typecheck` pass.