### PR TITLE
fix(env): coerce empty-string env vars to undefined before validation

### DIFF
--- a/.changeset/env-empty-string-coercion.md
+++ b/.changeset/env-empty-string-coercion.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/nextmedal": patch
+---
+
+Coerce empty-string environment variables to `undefined` before validation. CI/CD systems expand unset secrets (e.g. GitHub Actions `${{ secrets.MISSING }}`) to `""`, which previously slipped past `.optional()` and then failed `url()` / `min(1)` validation — crashing every request at runtime with "Invalid environment variables". Optional vars passed as empty strings are now treated as absent, so a deploy with some optional secrets unconfigured boots correctly.

--- a/src/lib/core/env.ts
+++ b/src/lib/core/env.ts
@@ -31,8 +31,13 @@ const envSchema = z.object({
   MEDAL_API_ENDPOINT: z.url().optional(),
 });
 
-// Validate env vars at runtime
-const parsedEnv = envSchema.safeParse({
+// CI/CD systems expose *unset* secrets as empty strings rather than omitting
+// them (e.g. GitHub Actions `${{ secrets.MISSING }}` expands to ""). An empty
+// string is not `undefined`, so it slips past `.optional()` and then fails
+// `url()` / `min(1)` validation — taking the whole site down at runtime with
+// "Invalid environment variables". Coerce "" to undefined so optional vars
+// validate as absent. (Mirrors @t3-oss/env's `emptyStringAsUndefined`.)
+const rawEnv: Record<string, string | undefined> = {
   NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
   NODE_ENV: process.env.NODE_ENV,
   VERCEL_ENV: process.env.VERCEL_ENV,
@@ -47,7 +52,13 @@ const parsedEnv = envSchema.safeParse({
   NEXT_PUBLIC_IMAGE_PROXY_URL: process.env.NEXT_PUBLIC_IMAGE_PROXY_URL,
   MEDAL_API_KEY: process.env.MEDAL_API_KEY,
   MEDAL_API_ENDPOINT: process.env.MEDAL_API_ENDPOINT,
-});
+};
+for (const key in rawEnv) {
+  if (rawEnv[key] === '') rawEnv[key] = undefined;
+}
+
+// Validate env vars at runtime
+const parsedEnv = envSchema.safeParse(rawEnv);
 
 const isBuildTime = process.env.NEXT_PHASE === 'phase-production-build';
 

--- a/tests/unit/lib/env.test.ts
+++ b/tests/unit/lib/env.test.ts
@@ -248,6 +248,47 @@ describe('env', () => {
     });
   });
 
+  describe('empty-string env vars (CI/CD unset secrets)', () => {
+    // GitHub Actions (and most CI systems) expand an unset secret reference such
+    // as `${{ secrets.MISSING }}` to "" rather than omitting it. An empty string
+    // is not `undefined`, so without coercion it slips past `.optional()` and
+    // then fails `url()` / `min(1)`, 500-ing every request at runtime.
+    it('treats an empty optional URL var as undefined instead of throwing', async () => {
+      process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL = '';
+
+      const { env } = await import('@/lib/core/env');
+
+      expect(env.NEXT_PUBLIC_UMAMI_SCRIPT_URL).toBeUndefined();
+    });
+
+    it('treats an empty optional min(1) var as undefined instead of throwing', async () => {
+      process.env.MEDAL_API_KEY = '';
+
+      const { env } = await import('@/lib/core/env');
+
+      expect(env.MEDAL_API_KEY).toBeUndefined();
+    });
+
+    it('survives the full set of unset CI secrets passed as empty strings', async () => {
+      // Reproduces the original outage: the Cloudflare deploy workflow forwards
+      // every optional secret via `${{ secrets.X }}`, so unconfigured ones arrive
+      // as "". Validation must still pass and the site must boot.
+      process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL = '';
+      process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID = '';
+      process.env.NEXT_PUBLIC_IMAGE_PROXY_URL = '';
+      process.env.NEXT_PUBLIC_SANITY_BROWSER_TOKEN = '';
+      process.env.SANITY_WRITE_TOKEN = '';
+      process.env.MEDAL_API_KEY = '';
+      process.env.MEDAL_API_ENDPOINT = '';
+
+      const { env } = await import('@/lib/core/env');
+
+      expect(env.NEXT_PUBLIC_BASE_URL).toBe('https://example.com');
+      expect(env.NEXT_PUBLIC_UMAMI_SCRIPT_URL).toBeUndefined();
+      expect(env.MEDAL_API_ENDPOINT).toBeUndefined();
+    });
+  });
+
   describe('build-time behavior', () => {
     it('does not throw during build phase with invalid env', async () => {
       process.env.NEXT_PHASE = 'phase-production-build';


### PR DESCRIPTION
## Problem

The first **CI** Cloudflare deploy of `nextmedal-staging` built and shipped successfully but returned **HTTP 500 on every request**. Production was unaffected only because the earlier manual build happened not to set the offending vars.

Root cause is in `src/lib/core/env.ts`. The deploy workflow forwards every optional secret to the build via `${{ secrets.X }}`. GitHub Actions expands an **unset** secret to an **empty string**, not nothing. `""` is not `undefined`, so it slips past `.optional()` and then fails the field's `url()` / `min(1)` check:

```
NEXT_PUBLIC_UMAMI_SCRIPT_URL  ""  -> Invalid URL
MEDAL_API_KEY                 ""  -> Too small: expected string to have >=1 characters
MEDAL_API_ENDPOINT            ""  -> Invalid URL
```

`safeParse` fails → `throw new Error('Invalid environment variables')` at module evaluation → the Worker 500s.

## Fix

Coerce empty strings to `undefined` before validation (mirrors `@t3-oss/env`'s `emptyStringAsUndefined`). Optional vars passed as `""` now validate as absent, so a deploy with some optional secrets unconfigured boots correctly.

## Tests

- `tests/unit/lib/env.test.ts`: new `empty-string env vars (CI/CD unset secrets)` block — empty optional `url()` var, empty optional `min(1)` var, and the full set of unset CI secrets as `""`. 32 pass.
- `pnpm typecheck` + `pnpm lint` clean.
