### PR TITLE
promote: pin third-party actions to SHAs

### DIFF
--- a/.changeset/pin-action-shas.md
+++ b/.changeset/pin-action-shas.md
@@ -1,0 +1,5 @@
+---
+"@medalsocial/nextmedal": patch
+---
+
+Pin all third-party GitHub Actions to commit SHAs (supply-chain hardening). The deploy workflows (`cloudflare-prod`/`cloudflare-staging`) run with the Cloudflare API token and Worker secrets, so a compromised version tag on an action would have been able to exfiltrate them. `cloudflare/wrangler-action`, `actions/checkout`, `actions/setup-node`, `pnpm/action-setup`, and `actions/github-script` are now pinned to immutable SHAs (`# vN` retained as a comment for readability).

--- a/.github/workflows/cloudflare-prod.yml
+++ b/.github/workflows/cloudflare-prod.yml
@@ -44,13 +44,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -62,7 +62,7 @@ jobs:
         run: pnpm exec opennextjs-cloudflare build
 
       - name: Deploy to Cloudflare
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/cloudflare-staging.yml
+++ b/.github/workflows/cloudflare-staging.yml
@@ -49,13 +49,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -71,7 +71,7 @@ jobs:
       # `--keep-vars` preserves existing Worker vars/secrets during the window
       # between deploy and secret reconciliation.
       - name: Deploy to Cloudflare
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/request-changeset.yml
+++ b/.github/workflows/request-changeset.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -64,7 +64,7 @@ jobs:
       - name: Find existing bot comment
         id: find
         if: steps.check.outputs.needed == 'true' || steps.check.outputs.needed == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const marker = '<!-- request-changeset-bot -->';
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upsert nudge comment
         if: steps.check.outputs.needed == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           EXISTING_ID: ${{ steps.find.outputs.id }}
         with:
@@ -113,7 +113,7 @@ jobs:
 
       - name: Resolve nudge once changeset is added
         if: steps.check.outputs.needed == 'false' && steps.find.outputs.id != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           EXISTING_ID: ${{ steps.find.outputs.id }}
         with:


### PR DESCRIPTION
Promotes #353 (supply-chain hardening: SHA-pin actions) to prod. Verified on staging — the pinned `wrangler-action` deploys cleanly (staging 200).